### PR TITLE
Add a Drawing Manager component

### DIFF
--- a/packages/gmap-vue/examples/drawing-manager.html
+++ b/packages/gmap-vue/examples/drawing-manager.html
@@ -1,0 +1,43 @@
+<body>
+  <div id="root">
+    <gmap-map ref="mapRef" :zoom="7" :center="center" map-type-id="roadmap" style="width: 100%; height: 500px">
+        <gmap-marker v-for="(m, index) in markers" :key="index" :position="m.location" :clickable="true" :draggable="true" @click="center=m.location" />
+        <gmap-drawing-manager drawingMode="rectangle" :options="{drawingControl: true, drawingControlOptions: {drawingModes: ['rectangle']}}" @rectanglecomplete="onEvent('rect', $event)"" />
+    </gmap-map>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="gmap-vue.js"></script>
+
+  <script>
+
+    Vue.use(VueGoogleMaps, {
+      load: {
+        key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
+        libraries: 'visualization,drawing'
+      },
+    });
+
+    document.addEventListener('DOMContentLoaded', function () {
+      new Vue({
+        el: '#root',
+        data: {
+          center: {lat:4.5, lng: 99},
+          markers: [
+            { location: new google.maps.LatLng({ lat: 3, lng: 101 }), weight: 100 },
+            { location: new google.maps.LatLng({ lat: 5, lng: 99 }), weight: 50  },
+            { location: new google.maps.LatLng({ lat: 6, lng: 97 }), weight: 80 },
+          ],	
+        },
+        methods: {
+          onEvent(name, evt) {
+            console.log(name);
+            console.log(evt);
+          }
+        }
+      });
+    });
+
+  </script>
+
+</body>

--- a/packages/gmap-vue/examples/heatmap-layer.html
+++ b/packages/gmap-vue/examples/heatmap-layer.html
@@ -1,0 +1,39 @@
+<body>
+  <div id="root">
+    <gmap-map ref="mapRef" :zoom="7" :center="center" map-type-id="roadmap" style="width: 100%; height: 500px">
+        <gmap-marker v-for="(m, index) in markers" :key="index" :position="m.location" :clickable="true" :draggable="true" @click="center=m.location" />
+        <gmap-heatmap :data="markers" :options="{maxIntensity: 120, dissipating: false}" />
+    </gmap-map>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="gmap-vue.js"></script>
+
+  <script>
+
+    Vue.use(VueGoogleMaps, {
+      load: {
+        key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
+        libraries: 'visualization'
+      },
+    });
+
+    document.addEventListener('DOMContentLoaded', function () {
+      new Vue({
+        el: '#root',
+        data: {
+          center: {lat:4.5, lng: 99},
+          markers: [
+            { location: new google.maps.LatLng({ lat: 3, lng: 101 }), weight: 100 },
+            { location: new google.maps.LatLng({ lat: 5, lng: 99 }), weight: 50  },
+            { location: new google.maps.LatLng({ lat: 6, lng: 97 }), weight: 80 },
+          ],	
+        },
+        methods: {
+        }
+      });
+    });
+
+  </script>
+
+</body>

--- a/packages/gmap-vue/src/components/drawing-manager.js
+++ b/packages/gmap-vue/src/components/drawing-manager.js
@@ -1,4 +1,4 @@
-import {gmapApi, MapElementFactory} from 'gmap-vue';
+import mapElementFactory from '../factories/map-element';
 
 const props = {
 	drawingMode: {
@@ -28,7 +28,7 @@ const events = [
  */
 export default MapElementFactory({
 	name: 'drawingManager',
-	ctr: () => gmapApi().maps.drawing.DrawingManager,
+	ctr: () => google.maps.drawing.DrawingManager,
 	events: events,
 	mappedProps: props,
 });

--- a/packages/gmap-vue/src/components/drawing-manager.js
+++ b/packages/gmap-vue/src/components/drawing-manager.js
@@ -26,7 +26,7 @@ const events = [
  *
  * Drawing Manager class
  */
-export default MapElementFactory({
+export default mapElementFactory({
 	name: 'drawingManager',
 	ctr: () => google.maps.drawing.DrawingManager,
 	events: events,

--- a/packages/gmap-vue/src/components/drawing-manager.js
+++ b/packages/gmap-vue/src/components/drawing-manager.js
@@ -1,0 +1,34 @@
+import {gmapApi, MapElementFactory} from 'gmap-vue';
+
+const props = {
+	drawingMode: {
+		type: String,
+		twoWay: true
+	},
+	options: {
+		type: Object,
+		twoWay: false,
+		default: () => {}
+	}
+};
+
+const events = [
+  'circlecomplete',
+  'markercomplete',
+  'overlaycomplete',
+  'polygoncomplete',
+  'polylinecomplete',
+  'rectanglecomplete'
+];
+
+/**
+ * @class Drawing Manager
+ *
+ * Drawing Manager class
+ */
+export default MapElementFactory({
+	name: 'drawingManager',
+	ctr: () => gmapApi().maps.drawing.DrawingManager,
+	events: events,
+	mappedProps: props,
+});

--- a/packages/gmap-vue/src/components/heatmap-layer.js
+++ b/packages/gmap-vue/src/components/heatmap-layer.js
@@ -19,7 +19,7 @@ const events = [];
  *
  * Heatmap Layer class
  */
-export default MapElementFactory({
+export default mapElementFactory({
     mappedProps: props,
     events: events,
     name: 'heatmapLayer',

--- a/packages/gmap-vue/src/components/heatmap-layer.js
+++ b/packages/gmap-vue/src/components/heatmap-layer.js
@@ -1,0 +1,27 @@
+import mapElementFactory from '../factories/map-element'
+
+const props = {
+    options: {
+        type: Object,
+        twoWay: false,
+        default: () => {},
+    },
+    data: {
+        type: Array,
+        twoWay: true        
+    },
+};
+
+const events = [];
+
+/**
+ * @class Heatmap Layer
+ *
+ * Heatmap Layer class
+ */
+export default MapElementFactory({
+    mappedProps: props,
+    events: events,
+    name: 'heatmapLayer',
+    ctr: () => google.maps.visualization.HeatmapLayer
+});

--- a/packages/gmap-vue/src/main.js
+++ b/packages/gmap-vue/src/main.js
@@ -3,6 +3,7 @@ import promiseLazyFactory from './factories/promise-lazy'
 
 import KmlLayer from './components/kml-layer'
 import HeatmapLayer from './components/heatmap-layer'
+import DrawingManager from './components/drawing-manager'
 import Marker from './components/marker'
 import Polyline from './components/polyline'
 import Polygon from './components/polygon'
@@ -34,7 +35,7 @@ let GmapApi = null
 
 // export everything
 export {
-  loadGmapApi, HeatmapLayer, KmlLayer, Marker, Polyline, Polygon, Circle, Cluster, Rectangle,
+  loadGmapApi, HeatmapLayer, DrawingManager, KmlLayer, Marker, Polyline, Polygon, Circle, Cluster, Rectangle,
   InfoWindow, Map, PlaceInput, MapElementMixin, MapElementFactory, Autocomplete,
   MountableMixin, StreetViewPanorama
 }
@@ -77,6 +78,7 @@ export function install (Vue, options) {
     Vue.component('GmapMarker', Marker)
     Vue.component('GmapInfoWindow', InfoWindow)
     Vue.component('GmapHeatmapLayer', HeatmapLayer)
+    Vue.component('GmapDrawingManager', DrawingManager)
     Vue.component('GmapKmlLayer', KmlLayer)
     Vue.component('GmapPolyline', Polyline)
     Vue.component('GmapPolygon', Polygon)

--- a/packages/gmap-vue/src/main.js
+++ b/packages/gmap-vue/src/main.js
@@ -2,6 +2,7 @@ import loadGmapApi from './manager/initializer'
 import promiseLazyFactory from './factories/promise-lazy'
 
 import KmlLayer from './components/kml-layer'
+import HeatmapLayer from './components/heatmap-layer'
 import Marker from './components/marker'
 import Polyline from './components/polyline'
 import Polygon from './components/polygon'
@@ -33,7 +34,7 @@ let GmapApi = null
 
 // export everything
 export {
-  loadGmapApi, KmlLayer, Marker, Polyline, Polygon, Circle, Cluster, Rectangle,
+  loadGmapApi, HeatmapLayer, KmlLayer, Marker, Polyline, Polygon, Circle, Cluster, Rectangle,
   InfoWindow, Map, PlaceInput, MapElementMixin, MapElementFactory, Autocomplete,
   MountableMixin, StreetViewPanorama
 }
@@ -75,6 +76,7 @@ export function install (Vue, options) {
     Vue.component('GmapMap', Map)
     Vue.component('GmapMarker', Marker)
     Vue.component('GmapInfoWindow', InfoWindow)
+    Vue.component('GmapHeatmapLayer', HeatmapLayer)
     Vue.component('GmapKmlLayer', KmlLayer)
     Vue.component('GmapPolyline', Polyline)
     Vue.component('GmapPolygon', Polygon)


### PR DESCRIPTION
I needed to be able to draw regions on my map in Vue so I added a Drawing Manager component. Thought it would be useful to others so here it is.

I have set it up for rectangles in the example but you can use any of the Google Maps drawing capability - see the Google Maps Drawing Layer documentation. You should only need to set the options and listen to the events: 
[https://developers.google.com/maps/documentation/javascript/drawinglayer](https://developers.google.com/maps/documentation/javascript/drawinglayer) 