### PR TITLE
feat(gmap-vue): add a drawing manager component

### DIFF
--- a/packages/gmap-vue/examples/drawing-manager.html
+++ b/packages/gmap-vue/examples/drawing-manager.html
@@ -45,7 +45,7 @@
 
   <script>
 
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
         libraries: 'places,drawing'

--- a/packages/gmap-vue/examples/drawing-manager.html
+++ b/packages/gmap-vue/examples/drawing-manager.html
@@ -1,0 +1,137 @@
+<body>
+  <div id="root">
+    <h1>Drawing Manager Example</h1>
+    <div style="width:100%">
+      <span style="width:auto" />
+      {{ mapMode }} - {{ toolbarPosition }}
+      <span style="width:auto" />
+      <button @click="setPos">Position</button>
+      <button @click="mapMode='edit'">Edit</button>
+    </div>
+    <br />
+	  <gmap-map
+	    ref="mapRef"
+	    :center="mapCenter"
+	    :zoom="17"
+	    map-type-id="roadmap"
+	    style="width: 100%; height: 100%"
+	    :options="{
+	      zoomControl: true,
+	      mapTypeControl: true,
+	      scaleControl: false,
+	      streetViewControl: false,
+	      rotateControl: false,
+	      fullscreenControl: false,
+	      disableDefaultUi: false,
+	      draggable: mapDraggable,
+	      draggableCursor: mapCursor
+	    }"
+	  >
+	    <template #visible>
+	      <gmap-drawing-manager
+	        v-if="mapMode==='edit'"
+	        :position="toolbarPosition"
+	        :rectangle-options="rectangleOptions"
+	        :circle-options="circleOptions"
+	        :polyline-options="polylineOptions"
+	        :shapes="shapes"
+	      />
+	    </template>
+	  </gmap-map>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="gmap-vue.js"></script>
+
+  <script>
+
+    Vue.use(VueGoogleMaps, {
+      load: {
+        key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
+        libraries: 'places,drawing'
+      },
+    });
+
+    document.addEventListener('DOMContentLoaded', function () {
+      new Vue({
+        el: '#root',
+        data: {
+			mapCenter: {lat: 0, lng: 0},
+			mapMode: null,
+			toolbarPosition: 'TOP_CENTER',
+		    mapDraggable: true,
+		    mapCursor: null,
+		    shapes: [],
+		    rectangleOptions: {
+		      fillColor: '#777',
+		      fillOpacity: 0.4,
+		      strokeWeight: 2,
+		      strokeColor: '#999',
+		      draggable: false,
+		      editable: false,
+		      clickable: true
+		    },
+		    circleOptions: {
+		      fillColor: '#777',
+		      fillOpacity: 0.4,
+		      strokeWeight: 2,
+		      strokeColor: '#999',
+		      draggable: false,
+		      editable: false,
+		      clickable: true
+		    },
+		    polylineOptions: {
+		      fillColor: '#777',
+		      fillOpacity: 0.4,
+		      strokeWeight: 2,
+		      strokeColor: '#999',
+		      draggable: false,
+		      editable: false,
+		      clickable: true
+		    }
+        },
+		watch: {
+			mapMode (newMode, oldMode) {
+				if (newMode === 'ready') {
+					if (oldMode === 'edit') {
+						this.mapDraggable = true;
+						this.mapCursor = null;
+						return;
+					}
+				}
+
+				if (newMode === 'edit') {
+					this.mapDraggable = false;
+					this.mapCursor = 'default';
+				}
+			}
+		},
+		mounted () {
+			this.mapMode = 'ready';
+		},
+        methods: {
+		    setPos () {
+		      const posTypes = [
+		        'TOP_CENTER',
+		        'TOP_LEFT',
+		        'TOP_RIGHT',
+		        'LEFT_TOP',
+		        'RIGHT_TOP',
+		        'LEFT_CENTER',
+		        'RIGHT_CENTER',
+		        'LEFT_BOTTOM',
+		        'RIGHT_BOTTOM',
+		        'BOTTOM_CENTER',
+		        'BOTTOM_LEFT',
+		        'BOTTOM_RIGHT'
+		      ];
+		
+		      this.toolbarPosition = posTypes[Math.floor(Math.random() * posTypes.length)];
+		    }
+        }
+      });
+    });
+
+  </script>
+
+</body>

--- a/packages/gmap-vue/examples/drawing-manager2.html
+++ b/packages/gmap-vue/examples/drawing-manager2.html
@@ -51,7 +51,7 @@
 
   <script>
 
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
         libraries: 'places,drawing'

--- a/packages/gmap-vue/examples/drawing-manager2.html
+++ b/packages/gmap-vue/examples/drawing-manager2.html
@@ -32,7 +32,6 @@
             v-slot="on"
 	        :rectangle-options="rectangleOptions"
 	        :circle-options="circleOptions"
-	        :polyline-options="polylineOptions"
 	        :shapes="shapes"
 	      >
 			  <div>

--- a/packages/gmap-vue/examples/drawing-manager2.html
+++ b/packages/gmap-vue/examples/drawing-manager2.html
@@ -86,30 +86,28 @@
 		      clickable: true
 		    },
         },
-		watch: {
-			mapMode (newMode, oldMode) {
-				if (newMode === 'ready') {
-					if (oldMode === 'edit') {
-						this.mapDraggable = true;
-						this.mapCursor = null;
-						return;
-					}
-				}
+        watch: {
+          mapMode(newMode, oldMode) {
+            if (newMode === "ready") {
+              if (oldMode === "edit") {
+                this.mapDraggable = true;
+                this.mapCursor = null;
+                return;
+              }
+            }
 
-				if (newMode === 'edit') {
-					this.mapDraggable = false;
-					this.mapCursor = 'default';
-				}
-			}
-		},
-		mounted () {
-			this.mapMode = 'ready';
-		},
-        methods: {
-        }
+            if (newMode === "edit") {
+              this.mapDraggable = false;
+              this.mapCursor = "default";
+            }
+          },
+        },
+        mounted() {
+          this.mapMode = "ready";
+        },
+        methods: {},
       });
     });
-
   </script>
 
 </body>

--- a/packages/gmap-vue/examples/drawing-manager2.html
+++ b/packages/gmap-vue/examples/drawing-manager2.html
@@ -34,9 +34,9 @@
 	        :shapes="shapes"
 	      >
 			  <div>
-			    <button @click="on.setDrawingMode('rectangle')">Rectangle</button>
-			    <button @click="on.setDrawingMode('circle')">Circle</button>
-			    <button @click="on.deleteSelection()">Delete</button>
+			    <button @click="setDrawingMode('rectangle')">Rectangle</button>
+			    <button @click="setDrawingMode('circle')">Circle</button>
+			    <button @click="deleteSelection()">Delete</button>
 			    <button @click="mapMode='ready'">Save</button>
 			  </div>
 	      </gmap-drawing-manager>

--- a/packages/gmap-vue/examples/drawing-manager2.html
+++ b/packages/gmap-vue/examples/drawing-manager2.html
@@ -1,0 +1,115 @@
+<body>
+  <div id="root">
+    <h1>Drawing Manager Example</h1>
+    <div style="width:100%">
+      <span style="width:auto" />
+      {{ mapMode }}
+      <span style="width:auto" />
+      <button @click="mapMode='edit'">Edit</button>
+    </div>
+    <br />
+	  <gmap-map
+	    ref="mapRef"
+	    :center="mapCenter"
+	    :zoom="17"
+	    map-type-id="roadmap"
+	    style="width: 100%; height: 100%"
+	    :options="{
+	      zoomControl: true,
+	      mapTypeControl: true,
+	      scaleControl: false,
+	      streetViewControl: false,
+	      rotateControl: false,
+	      fullscreenControl: false,
+	      disableDefaultUi: false,
+	      draggable: mapDraggable,
+	      draggableCursor: mapCursor
+	    }"
+	  >
+	    <template #visible>
+	      <gmap-drawing-manager
+	        v-if="mapMode==='edit'"
+            v-slot="on"
+	        :rectangle-options="rectangleOptions"
+	        :circle-options="circleOptions"
+	        :polyline-options="polylineOptions"
+	        :shapes="shapes"
+	      >
+			  <div>
+			    <button @click="on.setDrawingMode('rectangle')">Rectangle</button>
+			    <button @click="on.setDrawingMode('circle')">Circle</button>
+			    <button @click="on.deleteSelection()">Delete</button>
+			    <button @click="mapMode='ready'">Save</button>
+			  </div>
+	      </gmap-drawing-manager>
+	    </template>
+	  </gmap-map>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="gmap-vue.js"></script>
+
+  <script>
+
+    Vue.use(VueGoogleMaps, {
+      load: {
+        key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
+        libraries: 'places,drawing'
+      },
+    });
+
+    document.addEventListener('DOMContentLoaded', function () {
+      new Vue({
+        el: '#root',
+        data: {
+			mapCenter: {lat: 0, lng: 0},
+			mapMode: null,
+		    mapDraggable: true,
+		    mapCursor: null,
+		    shapes: [],
+		    rectangleOptions: {
+		      fillColor: '#777',
+		      fillOpacity: 0.4,
+		      strokeWeight: 2,
+		      strokeColor: '#999',
+		      draggable: false,
+		      editable: false,
+		      clickable: true
+		    },
+		    circleOptions: {
+		      fillColor: '#777',
+		      fillOpacity: 0.4,
+		      strokeWeight: 2,
+		      strokeColor: '#999',
+		      draggable: false,
+		      editable: false,
+		      clickable: true
+		    },
+        },
+		watch: {
+			mapMode (newMode, oldMode) {
+				if (newMode === 'ready') {
+					if (oldMode === 'edit') {
+						this.mapDraggable = true;
+						this.mapCursor = null;
+						return;
+					}
+				}
+
+				if (newMode === 'edit') {
+					this.mapDraggable = false;
+					this.mapCursor = 'default';
+				}
+			}
+		},
+		mounted () {
+			this.mapMode = 'ready';
+		},
+        methods: {
+        }
+      });
+    });
+
+  </script>
+
+</body>

--- a/packages/gmap-vue/examples/drawing-manager2.html
+++ b/packages/gmap-vue/examples/drawing-manager2.html
@@ -29,7 +29,6 @@
 	    <template #visible>
 	      <gmap-drawing-manager
 	        v-if="mapMode==='edit'"
-            v-slot="on"
 	        :rectangle-options="rectangleOptions"
 	        :circle-options="circleOptions"
 	        :shapes="shapes"

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -111,8 +111,9 @@ export default mapElementFactory({
       }
     },
     polygonOptions (polygonOptions) {
-      if (this.$drawingmanagerObject) {
-        this.$drawingmanagerObject.setOptions({ polygonOptions });
+      if (this.$drawingManagerObject) {
+        this.$drawingManagerObject.setOptions({ polygonOptions });
+
       }
     },
     polylineOptions (polylineOptions) {

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -104,8 +104,9 @@ export default mapElementFactory({
       }
     },
     circleOptions (circleOptions) {
-      if (this.$drawingmanagerObject) {
-        this.$drawingmanagerObject.setOptions({ circleOptions });
+      if (this.$drawingManagerObject) {
+        this.$drawingManagerObject.setOptions({ circleOptions });
+
       }
     },
     markerOptions (markerOptions) {

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -105,8 +105,9 @@ export default mapElementFactory({
       }
     },
     markerOptions (markerOptions) {
-      if (this.$drawingmanagerObject) {
-        this.$drawingmanagerObject.setOptions({ markerOptions });
+      if (this.$drawingManagerObject) {
+        this.$drawingManagerObject.setOptions({ markerOptions });
+
       }
     },
     polygonOptions (polygonOptions) {

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -82,7 +82,8 @@ export default mapElementFactory({
   },
   destroyed () {
     this.clearAll();
-    this.$drawingmanagerObject.setMap(null);
+    this.$drawingManagerObject.setMap(null);
+
   },
 
   data: () => ({

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -73,7 +73,8 @@ export default mapElementFactory({
     return options;
   },
   afterCreate () {
-    this.$drawingmanagerObject.addListener('overlaycomplete', (e) => this.addShape(e));
+    this.$drawingManagerObject.addListener('overlaycomplete', (e) => this.addShape(e));
+
     this.$map.addListener('click', this.clearSelection);
     if (this.shapes.length > 0) {
       this.drawAll();

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -39,7 +39,7 @@ const props = {
 };
 
 export default mapElementFactory({
-  name: 'drawingmanager',
+  name: 'drawingManager',
   ctr: () => google.maps.drawing.DrawingManager,
   options: {
     drawingControl: true,

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -151,9 +151,9 @@ export default mapElementFactory({
     },
     clearAll () {
       this.clearSelection();
-      for (const shape of this.shapes) {
+      this.shapes.forEach((shape) => {
         shape.overlay.setMap(null);
-      }
+      });
     },
     clearSelection () {
       if (this.selectedShape) {

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -91,7 +91,8 @@ export default mapElementFactory({
 
   watch: {
     position (position) {
-      if (this.$drawingmanagerObject) {
+      if (this.$drawingManagerObject) {
+
         const drawingControlOptions = {
           position: (position && google.maps.ControlPosition[position])
             ? google.maps.ControlPosition[position]

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -51,13 +51,15 @@ export default mapElementFactory({
   props,
   events: [],
   beforeCreate (options) {
-    const drawingModes = [];
-    for (const opt of Object.keys(options)) {
+    const drawingModes = Object.keys(options).reduce((modes, opt) => {
       const val = opt.split('Options');
+
       if (val.length > 1) {
-        drawingModes.push(val[0]);
+        modes.push(val[0]);
       }
-    }
+      
+      return modes;
+    }, []);
     const position = (this.position && google.maps.ControlPosition[this.position])
       ? google.maps.ControlPosition[this.position]
       : google.maps.ControlPosition.TOP_LEFT;

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -1,0 +1,192 @@
+import mapElementFactory from '../factories/map-element';
+
+const mappedProps = {
+  circleOptions: {
+    type: Object,
+    twoWay: false,
+    noBind: true
+  },
+  markerOptions: {
+    type: Object,
+    twoWay: false,
+    noBind: true
+  },
+  polygonOptions: {
+    type: Object,
+    twoWay: false,
+    noBind: true
+  },
+  polylineOptions: {
+    type: Object,
+    twoWay: false,
+    noBind: true
+  },
+  rectangleOptions: {
+    type: Object,
+    twoWay: false,
+    noBind: true
+  }
+};
+
+const props = {
+  position: {
+    type: String
+  },
+  shapes: {
+    type: Array,
+    required: true
+  }
+};
+
+export default mapElementFactory({
+  name: 'drawingmanager',
+  ctr: () => google.maps.drawing.DrawingManager,
+  options: {
+    drawingControl: true,
+    drawingControlOptions: {
+    },
+    drawingMode: null
+  },
+  mappedProps,
+  props,
+  events: [],
+  beforeCreate (options) {
+    const drawingModes = [];
+    for (const opt of Object.keys(options)) {
+      const val = opt.split('Options');
+      if (val.length > 1) {
+        drawingModes.push(val[0]);
+      }
+    }
+    const position = (this.position && google.maps.ControlPosition[this.position])
+      ? google.maps.ControlPosition[this.position]
+      : google.maps.ControlPosition.TOP_LEFT;
+
+    options.drawingMode = null;
+    options.drawingControl = !this.$scopedSlots.default;
+    options.drawingControlOptions = {
+      drawingModes,
+      position
+    };
+    return options;
+  },
+  afterCreate () {
+    this.$drawingmanagerObject.addListener('overlaycomplete', (e) => this.addShape(e));
+    this.$map.addListener('click', this.clearSelection);
+    if (this.shapes.length > 0) {
+      this.drawAll();
+    }
+  },
+  destroyed () {
+    this.clearAll();
+    this.$drawingmanagerObject.setMap(null);
+  },
+
+  data: () => ({
+    selectedShape: null
+  }),
+
+  watch: {
+    position (position) {
+      if (this.$drawingmanagerObject) {
+        const drawingControlOptions = {
+          position: (position && google.maps.ControlPosition[position])
+            ? google.maps.ControlPosition[position]
+            : google.maps.ControlPosition.TOP_LEFT
+        };
+        this.$drawingmanagerObject.setOptions({ drawingControlOptions });
+      }
+    },
+    circleOptions (circleOptions) {
+      if (this.$drawingmanagerObject) {
+        this.$drawingmanagerObject.setOptions({ circleOptions });
+      }
+    },
+    markerOptions (markerOptions) {
+      if (this.$drawingmanagerObject) {
+        this.$drawingmanagerObject.setOptions({ markerOptions });
+      }
+    },
+    polygonOptions (polygonOptions) {
+      if (this.$drawingmanagerObject) {
+        this.$drawingmanagerObject.setOptions({ polygonOptions });
+      }
+    },
+    polylineOptions (polylineOptions) {
+      if (this.$drawingmanagerObject) {
+        this.$drawingmanagerObject.setOptions({ polylineOptions });
+      }
+    },
+    rectangleOptions (rectangleOptions) {
+      if (this.$drawingmanagerObject) {
+        this.$drawingmanagerObject.setOptions({ rectangleOptions });
+      }
+    }
+  },
+
+  methods: {
+    setDrawingMode (mode) {
+      this.$drawingmanagerObject.setDrawingMode(mode);
+    },
+    drawAll () {
+      const shapeType = {
+        circle: google.maps.Circle,
+        marker: google.maps.Marker,
+        polygon: google.maps.Polygon,
+        polyline: google.maps.Polyline,
+        rectangle: google.maps.Rectangle
+      };
+
+      const _this = this;
+      for (const shape of this.shapes) {
+        const shapeDrawing = new shapeType[shape.type](shape.overlay);
+        shapeDrawing.setMap(this.$map);
+        shape.overlay = shapeDrawing;
+        google.maps.event.addListener(shapeDrawing, 'click', () => {
+          _this.setSelection(shape);
+        });
+      }
+    },
+    clearAll () {
+      this.clearSelection();
+      for (const shape of this.shapes) {
+        shape.overlay.setMap(null);
+      }
+    },
+    clearSelection () {
+      if (this.selectedShape) {
+        this.selectedShape.overlay.set('fillColor', '#777');
+        this.selectedShape.overlay.set('strokeColor', '#999');
+        this.selectedShape.overlay.setEditable(false);
+        this.selectedShape.overlay.setDraggable(false);
+        this.selectedShape = null;
+      }
+    },
+    setSelection (shape) {
+      this.clearSelection();
+      this.selectedShape = shape;
+      shape.overlay.setEditable(true);
+      shape.overlay.setDraggable(true);
+      this.selectedShape.overlay.set('fillColor', '#555');
+      this.selectedShape.overlay.set('strokeColor', '#777');
+    },
+    deleteSelection () {
+      if (this.selectedShape) {
+        this.selectedShape.overlay.setMap(null);
+        const index = this.shapes.indexOf(this.selectedShape);
+        if (index > -1) {
+          this.shapes.splice(index, 1);
+        }
+      }
+    },
+    addShape (shape) {
+      this.setDrawingMode(null);
+      this.shapes.push(shape);
+      const _this = this;
+      google.maps.event.addListener(shape.overlay, 'click', () => {
+        _this.setSelection(shape);
+      });
+      this.setSelection(shape);
+    }
+  }
+});

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -140,14 +140,14 @@ export default mapElementFactory({
       };
 
       const _this = this;
-      for (const shape of this.shapes) {
+      this.shapes.forEach((shape) => {
         const shapeDrawing = new shapeType[shape.type](shape.overlay);
         shapeDrawing.setMap(this.$map);
         shape.overlay = shapeDrawing;
         google.maps.event.addListener(shapeDrawing, 'click', () => {
           _this.setSelection(shape);
         });
-      }
+      });
     },
     clearAll () {
       this.clearSelection();

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -132,7 +132,8 @@ export default mapElementFactory({
 
   methods: {
     setDrawingMode (mode) {
-      this.$drawingmanagerObject.setDrawingMode(mode);
+      this.$drawingManagerObject.setDrawingMode(mode);
+
     },
     drawAll () {
       const shapeType = {

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -117,8 +117,9 @@ export default mapElementFactory({
       }
     },
     polylineOptions (polylineOptions) {
-      if (this.$drawingmanagerObject) {
-        this.$drawingmanagerObject.setOptions({ polylineOptions });
+      if (this.$drawingManagerObject) {
+        this.$drawingManagerObject.setOptions({ polylineOptions });
+
       }
     },
     rectangleOptions (rectangleOptions) {

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -99,7 +99,8 @@ export default mapElementFactory({
             ? google.maps.ControlPosition[position]
             : google.maps.ControlPosition.TOP_LEFT
         };
-        this.$drawingmanagerObject.setOptions({ drawingControlOptions });
+        this.$drawingManagerObject.setOptions({ drawingControlOptions });
+
       }
     },
     circleOptions (circleOptions) {

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -123,8 +123,9 @@ export default mapElementFactory({
       }
     },
     rectangleOptions (rectangleOptions) {
-      if (this.$drawingmanagerObject) {
-        this.$drawingmanagerObject.setOptions({ rectangleOptions });
+      if (this.$drawingManagerObject) {
+        this.$drawingManagerObject.setOptions({ rectangleOptions });
+
       }
     }
   },

--- a/packages/gmap-vue/src/components/drawing-manager.vue
+++ b/packages/gmap-vue/src/components/drawing-manager.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <slot
+      :setDrawingMode="setDrawingMode"
+      :deleteSelection="deleteSelection"
+    />
+  </div>
+</template>
+
+<script>
+export default ((x) => x.default || x)(require('../components-implementation/drawing-manager'));
+</script>

--- a/packages/gmap-vue/src/main.js
+++ b/packages/gmap-vue/src/main.js
@@ -7,6 +7,7 @@ import Polyline from './components/polyline'
 import Polygon from './components/polygon'
 import Circle from './components/circle'
 import Rectangle from './components/rectangle'
+import DrawingManager from './components/drawing-manager.vue'
 
 // Vue component imports
 import InfoWindow from './components/info-window.vue'
@@ -33,7 +34,7 @@ let GmapApi = null
 
 // export everything
 export {
-  loadGmapApi, KmlLayer, Marker, Polyline, Polygon, Circle, Cluster, Rectangle,
+  loadGmapApi, KmlLayer, Marker, Polyline, Polygon, Circle, Cluster, Rectangle, DrawingManager,
   InfoWindow, Map, PlaceInput, MapElementMixin, MapElementFactory, Autocomplete,
   MountableMixin, StreetViewPanorama
 }
@@ -80,6 +81,7 @@ export function install (Vue, options) {
     Vue.component('GmapPolygon', Polygon)
     Vue.component('GmapCircle', Circle)
     Vue.component('GmapRectangle', Rectangle)
+    Vue.component('GmapDrawingManager', DrawingManager)
     Vue.component('GmapAutocomplete', Autocomplete)
     Vue.component('GmapPlaceInput', PlaceInput)
     Vue.component('GmapStreetViewPanorama', StreetViewPanorama)


### PR DESCRIPTION
This is a drawing manager component that brings up a UI for drawing shapes on your map. If you leave it empty, it will bring up the default DrawingManager toolbar, but you can also add your own toolbar into the default slot. In this case, slot scoped methods are provided to change the drawing mode, and delete selected shapes.

The mandatory shapes prop will contain all the drawn shapes. If this has existing shape data in it, they will be drawn onto the map when the editor is displayed.

Please test the examples first!