### PR TITLE
fix(gmap-vue): fix hit and drawer map components and examples (#56)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: npm
 install:
   - npm ci
 script:
+  - npm run test
   - npm run build
 deploy:
   provider: pages

--- a/packages/documentation/docs/.vuepress/components/eg-custom-drawing-toolbar.vue
+++ b/packages/documentation/docs/.vuepress/components/eg-custom-drawing-toolbar.vue
@@ -1,0 +1,10 @@
+<template>
+  <div style="background-color: #040404; display: flex; position: absolute; padding: 8px">
+    <div><button @click="$emit('drawingmode_changed', 'rectangle')">Rectangle</button></div>
+    <div><button @click="$emit('drawingmode_changed', 'circle')">Circle</button></div>
+    <div><button @click="$emit('drawingmode_changed', 'polyline')">Line</button></div>
+    <div><button @click="$emit('drawingmode_changed', 'polygon')">Polygon</button></div>
+    <div><button @click="$emit('delete_selection')">Delete</button></div>
+    <div><button @click="$emit('save')">Save</button></div>
+  </div>
+</template>

--- a/packages/documentation/docs/.vuepress/components/eg-drawing-manager-with-slot.vue
+++ b/packages/documentation/docs/.vuepress/components/eg-drawing-manager-with-slot.vue
@@ -1,23 +1,23 @@
 <template>
   <div id="container">
     <h3>Drawing Manager Example</h3>
-    <div style="width: 100%;">
+    <div style="width: 100%; display: flex; flex-direction: column;">
       <span style="width: auto;" />
       <ul>
         <li><strong>Mode:</strong> {{ mapMode }}</li>
       </ul>
       <span style="width: auto;" />
-      <button @click="setMapMode">
-        {{ mapMode === "ready" ? "Edit" : "Ready" }}
-      </button>
+      <div>
+        <button @click="mapMode = 'edit'">Edit</button>
+      </div>
     </div>
     <br />
     <gmap-map
       ref="mapRef"
       :center="mapCenter"
-      :zoom="17"
+      :zoom="7"
       map-type-id="roadmap"
-      style="width: 100%; height: 100%;"
+      style="width: 100%; height: 500px; display:flex; justify-content: center; align-items: flex-start;"
       :options="{
         zoomControl: true,
         mapTypeControl: true,
@@ -35,14 +35,17 @@
           v-if="mapMode === 'edit'"
           :rectangle-options="rectangleOptions"
           :circle-options="circleOptions"
+          :polyline-options="polylineOptions"
+          :polygon-options="polygonOptions"
           :shapes="shapes"
         >
-          <div>
-            <button @click="setDrawingMode('rectangle')">Rectangle</button>
-            <button @click="setDrawingMode('circle')">Circle</button>
-            <button @click="deleteSelection()">Delete</button>
-            <button @click="mapMode = 'ready'">Save</button>
-          </div>
+          <template v-slot="on">
+            <eg-custom-drawing-toolbar
+              @drawingmode_changed="on.setDrawingMode($event)"
+              @delete_selection="on.deleteSelection()"
+              @save="mapMode = 'ready'"
+            />
+          </template>
         </gmap-drawing-manager>
       </template>
     </gmap-map>
@@ -50,62 +53,72 @@
 </template>
 
 <script>
+
 export default {
-  name: "eg-drawing-manager-with-slot",
+  name: 'eg-drawing-manager-with-slot',
   data() {
     return {
-      mapCenter: { lat: 0, lng: 0 },
+      mapCenter: { lat: 4.5, lng: 99 },
       mapMode: null,
       mapDraggable: true,
       mapCursor: null,
       shapes: [],
       rectangleOptions: {
-        fillColor: "#777",
+        fillColor: '#777',
         fillOpacity: 0.4,
         strokeWeight: 2,
-        strokeColor: "#999",
+        strokeColor: '#999',
         draggable: false,
         editable: false,
         clickable: true
       },
       circleOptions: {
-        fillColor: "#777",
+        fillColor: '#777',
         fillOpacity: 0.4,
         strokeWeight: 2,
-        strokeColor: "#999",
+        strokeColor: '#999',
         draggable: false,
         editable: false,
         clickable: true
-      }
+      },
+      polylineOptions: {
+        fillColor: '#777',
+        fillOpacity: 0.4,
+        strokeWeight: 2,
+        strokeColor: '#999',
+        draggable: false,
+        editable: false,
+        clickable: true
+      },
+      polygonOptions: {
+        fillColor: '#777',
+        fillOpacity: 0.4,
+        strokeWeight: 2,
+        strokeColor: '#999',
+        draggable: false,
+        editable: false,
+        clickable: true
+      },
     };
   },
   watch: {
     mapMode(newMode, oldMode) {
-      if (newMode === "ready") {
-        if (oldMode === "edit") {
+      if (newMode === 'ready') {
+        if (oldMode === 'edit') {
           this.mapDraggable = true;
           this.mapCursor = null;
           return;
         }
       }
 
-      if (newMode === "edit") {
+      if (newMode === 'edit') {
         this.mapDraggable = false;
-        this.mapCursor = "default";
+        this.mapCursor = 'default';
       }
     }
   },
   mounted() {
-    this.mapMode = "ready";
-  },
-  methods: {
-    setMapMode() {
-      if (this.mapMode === "edit") {
-        this.mapMode = "ready";
-      } else {
-        this.mapMode = "edit";
-      }
-    }
+    this.mapMode = 'ready';
   }
 };
 </script>
@@ -113,7 +126,6 @@ export default {
 <style scoped>
 #container {
   width: 700px;
-  height: 300px;
-  margin-bottom: 9rem;
+  margin-bottom: 1rem;
 }
 </style>

--- a/packages/documentation/docs/.vuepress/components/eg-drawing-manager.vue
+++ b/packages/documentation/docs/.vuepress/components/eg-drawing-manager.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="container">
     <h3>Drawing Manager Example</h3>
-    <div style="width: 100%;">
+    <div style="width: 100%; display: flex; flex-direction: column;">
       <span style="width: auto;" />
       <ul>
         <li>
@@ -12,16 +12,18 @@
         </li>
       </ul>
       <span style="width: auto;" />
-      <button @click="setPos">Position</button>
-      <button @click="setMapMode">{{mapMode === 'ready' ? 'Edit' : 'Ready'}}</button>
+      <div>
+        <button @click="setPos">Position</button>
+        <button @click="setMapMode">{{mapMode === 'ready' ? 'change to Edit' : 'change to Ready'}}</button>
+      </div>
     </div>
     <br />
     <gmap-map
       ref="mapRef"
       :center="mapCenter"
-      :zoom="17"
+      :zoom="7"
       map-type-id="roadmap"
-      style="width: 100%; height: 100%;"
+      style="width: 100%; height: 500px"
       :options="{
         zoomControl: true,
         mapTypeControl: true,
@@ -53,35 +55,35 @@ export default {
   name: "eg-drawing-manager",
   data() {
     return {
-      mapCenter: { lat: 0, lng: 0 },
+      mapCenter: { lat: 4.5, lng: 99 },
       mapMode: null,
-      toolbarPosition: "TOP_CENTER",
+      toolbarPosition: 'TOP_CENTER',
       mapDraggable: true,
       mapCursor: null,
       shapes: [],
       rectangleOptions: {
-        fillColor: "#777",
+        fillColor: '#777',
         fillOpacity: 0.4,
         strokeWeight: 2,
-        strokeColor: "#999",
+        strokeColor: '#999',
         draggable: false,
         editable: false,
         clickable: true
       },
       circleOptions: {
-        fillColor: "#777",
+        fillColor: '#777',
         fillOpacity: 0.4,
         strokeWeight: 2,
-        strokeColor: "#999",
+        strokeColor: '#999',
         draggable: false,
         editable: false,
         clickable: true
       },
       polylineOptions: {
-        fillColor: "#777",
+        fillColor: '#777',
         fillOpacity: 0.4,
         strokeWeight: 2,
-        strokeColor: "#999",
+        strokeColor: '#999',
         draggable: false,
         editable: false,
         clickable: true
@@ -90,38 +92,38 @@ export default {
   },
   watch: {
     mapMode(newMode, oldMode) {
-      if (newMode === "ready") {
-        if (oldMode === "edit") {
+      if (newMode === 'ready') {
+        if (oldMode === 'edit') {
           this.mapDraggable = true;
           this.mapCursor = null;
           return;
         }
       }
 
-      if (newMode === "edit") {
+      if (newMode === 'edit') {
         this.mapDraggable = false;
-        this.mapCursor = "default";
+        this.mapCursor = 'default';
       }
     }
   },
   mounted() {
-    this.mapMode = "ready";
+    this.mapMode = 'ready';
   },
   methods: {
     setPos() {
       const posTypes = [
-        "TOP_CENTER",
-        "TOP_LEFT",
-        "TOP_RIGHT",
-        "LEFT_TOP",
-        "RIGHT_TOP",
-        "LEFT_CENTER",
-        "RIGHT_CENTER",
-        "LEFT_BOTTOM",
-        "RIGHT_BOTTOM",
-        "BOTTOM_CENTER",
-        "BOTTOM_LEFT",
-        "BOTTOM_RIGHT"
+        'TOP_CENTER',
+        'TOP_LEFT',
+        'TOP_RIGHT',
+        'LEFT_TOP',
+        'RIGHT_TOP',
+        'LEFT_CENTER',
+        'RIGHT_CENTER',
+        'LEFT_BOTTOM',
+        'RIGHT_BOTTOM',
+        'BOTTOM_CENTER',
+        'BOTTOM_LEFT',
+        'BOTTOM_RIGHT'
       ];
 
       this.toolbarPosition =
@@ -141,7 +143,6 @@ export default {
 <style scoped>
 #container {
   width: 700px;
-  height: 300px;
-  margin-bottom: 9rem;
+  margin-bottom: 1rem;
 }
 </style>

--- a/packages/documentation/docs/.vuepress/components/eg-heat-map-layer.vue
+++ b/packages/documentation/docs/.vuepress/components/eg-heat-map-layer.vue
@@ -1,9 +1,5 @@
 <template>
   <div>
-    <button @click="setMarkers">
-      Set markers on heatmap
-    </button>
-    <br /><br />
     <gmap-map
       ref="mapRef"
       :zoom="7"
@@ -29,30 +25,29 @@
 
 <script>
 export default {
-  name: "eg-heat-map-layer",
+  name: 'eg-heat-map-layer',
   data() {
     return {
       center: { lat: 4.5, lng: 99 },
       markers: [],
     }
   },
-  methods: {
-    setMarkers() {
-      this.markers = [
-        {
-          location: new google.maps.LatLng({ lat: 3, lng: 101 }),
-          weight: 100
-        },
-        {
-          location: new google.maps.LatLng({ lat: 5, lng: 99 }),
-          weight: 50
-        },
-        {
-          location: new google.maps.LatLng({ lat: 6, lng: 97 }),
-          weight: 80
-        }
-      ];
-    }
+  async mounted() {
+    await this.$gmapApiPromiseLazy();
+    this.markers = [
+      {
+        location: new google.maps.LatLng({ lat: 3, lng: 101 }),
+        weight: 100
+      },
+      {
+        location: new google.maps.LatLng({ lat: 5, lng: 99 }),
+        weight: 50
+      },
+      {
+        location: new google.maps.LatLng({ lat: 6, lng: 97 }),
+        weight: 80
+      }
+    ];
   }
 };
 </script>

--- a/packages/documentation/docs/.vuepress/components/set-valid-api-key.vue
+++ b/packages/documentation/docs/.vuepress/components/set-valid-api-key.vue
@@ -58,7 +58,6 @@ export default {
         googleMapScript.setAttribute('async', '')
         googleMapScript.setAttribute('defer', '')
         document.head.appendChild(googleMapScript)
-        document.head.appendChild(googleMapScript)
       }
 
       this.stateProcess = 'Gmap is ready :)'

--- a/packages/documentation/docs/README.md
+++ b/packages/documentation/docs/README.md
@@ -33,7 +33,7 @@ Just download `dist/gmap-vue.js` file and include it from your HTML.
 You can use a free CDN like [jsdelivr](https://www.jsdelivr.com) to include this plugin in your html file
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 ```
 
 ### unpkg
@@ -41,7 +41,7 @@ You can use a free CDN like [jsdelivr](https://www.jsdelivr.com) to include this
 You can use a free CDN like [unpkg](https://unpkg.com) to include this plugin in your html file
 
 ```html
-<script src="https://unpkg.com/gmap-vue@1.2.1/dist/gmap-vue.js"></script>
+<script src="https://unpkg.com/gmap-vue@1.2.2/dist/gmap-vue.js"></script>
 ```
 
 ::: warning
@@ -182,6 +182,83 @@ Vue.use(GmapVue, {
   },
 })
 ```
+
+### Lazy loading
+
+If you need to wait for google maps API to be ready, you can use the `this.$gmapApiPromiseLazy()` function to wait for it. This function is automatically added to your components when you use GmapVue plugin, also, you can find a reference of this function in your Vue instance if you have a reference of following common practice to assign it to `vm` variable.
+
+A simple example
+
+```js
+export default {
+  name: 'your-component-name',
+  data() {
+    return {
+      center: { lat: 4.5, lng: 99 },
+      markers: [],
+    }
+  },
+  async mounted() {
+    // if you have a reference of Vue in a `vm` variable
+    // the following option should work too
+    // await vm.$gmapApiPromiseLazy();
+
+    await this.$gmapApiPromiseLazy();
+    this.markers = [
+      {
+        location: new google.maps.LatLng({ lat: 3, lng: 101 }),
+        weight: 100
+      },
+      {
+        location: new google.maps.LatLng({ lat: 5, lng: 99 }),
+        weight: 50
+      },
+      {
+        location: new google.maps.LatLng({ lat: 6, lng: 97 }),
+        weight: 80
+      }
+    ];
+  }
+};
+```
+
+### GmapVue slots
+
+GmapVue has two slots with a different behavior.
+The default slot is wrapped in a class that sets `display: none;` so by default any component you add to your map will be invisible.
+
+This is ok for most of the supplied components that interact directly with the Google map object, but it's not good if you want to bring up things like toolboxes, etc.
+
+There is a second slot named **"visible"** that must be used if you want to display content within the responsive wrapper for the map, hence that's why you'll see this in the [drawing manager with slot example](/examples/drawing-manager-with-slot.html). It's actually not required in the [first example](/examples/drawing-manager.html) because the default toolbox is part of the Google map object.
+
+> Thanks to [@davydnorris](https://github.com/davydnorris) to document this part of GmapVue.
+
+### Accessing Google Maps API
+
+If you need to access the Google maps API directly you can use the exported `gmapApi()` function like this
+
+```js
+import { gmapApi } from 'gmap-vue';
+
+export default {
+  name: 'your-component-name',
+  data() {
+    return {
+      center: { lat: 4.5, lng: 99 },
+      markers: [],
+    }
+  },
+  computed: {
+    // The below example is the same as writing
+    // google() {
+    //   return gmapApi();
+    // },
+    google: gmapApi,
+  },
+};
+```
+
+You will get an object with a `maps` property and inside of it you can find all the Google maps API.
 
 ### Nuxt.js config
 

--- a/packages/documentation/docs/examples/README.md
+++ b/packages/documentation/docs/examples/README.md
@@ -15,7 +15,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="https://unpkg.com/gmap-vue@1.2.1/dist/gmap-vue.js"></script>
+  <script src="https://unpkg.com/gmap-vue@1.2.2/dist/gmap-vue.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/autocomplete.md
+++ b/packages/documentation/docs/examples/autocomplete.md
@@ -28,8 +28,8 @@
     </Gmap-Map>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/basic-autocomplete.md
+++ b/packages/documentation/docs/examples/basic-autocomplete.md
@@ -48,9 +48,9 @@
     </div>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/basic-marker-cluster.md
+++ b/packages/documentation/docs/examples/basic-marker-cluster.md
@@ -23,7 +23,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/markerclustererplus/2.1.4/markerclusterer.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/basic-marker-shape.md
+++ b/packages/documentation/docs/examples/basic-marker-shape.md
@@ -19,7 +19,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/drawing-manager-with-slot.md
+++ b/packages/documentation/docs/examples/drawing-manager-with-slot.md
@@ -4,13 +4,18 @@
   <eg-drawing-manager-with-slot />
 </eg-base>
 
+::: warning
+If you are using the runtime-only build the template on `toolbarTemplate` will not work, instead of that
+you need to pre-compile the templates into render functions, or use the compiler-included build.
+:::
+
 ## Source code
 
 ```html
 <body>
   <div id="root">
     <h1>Drawing Manager Example</h1>
-    <div style="width: 100%;">
+    <div style="width:100%; display: flex; justify-content: center;">
       <span style="width: auto;" />
       {{ mapMode }}
       <span style="width: auto;" />
@@ -20,98 +25,133 @@
     <gmap-map
       ref="mapRef"
       :center="mapCenter"
-      :zoom="17"
+      :zoom="7"
       map-type-id="roadmap"
-      style="width: 100%; height: 100%;"
+      style="width: 100%; height: 800px; display:flex; justify-content: center; align-items: flex-start;"
       :options="{
-	      zoomControl: true,
-	      mapTypeControl: true,
-	      scaleControl: false,
-	      streetViewControl: false,
-	      rotateControl: false,
-	      fullscreenControl: false,
-	      disableDefaultUi: false,
-	      draggable: mapDraggable,
-	      draggableCursor: mapCursor
-	    }"
+        zoomControl: true,
+        mapTypeControl: true,
+        scaleControl: false,
+        streetViewControl: false,
+        rotateControl: false,
+        fullscreenControl: false,
+        disableDefaultUi: false,
+        draggable: mapDraggable,
+        draggableCursor: mapCursor
+      }"
     >
       <template #visible>
         <gmap-drawing-manager
           v-if="mapMode==='edit'"
           :rectangle-options="rectangleOptions"
           :circle-options="circleOptions"
+          :polyline-options="polylineOptions"
+          :polygon-options="polygonOptions"
           :shapes="shapes"
         >
-          <div>
-            <button @click="setDrawingMode('rectangle')">Rectangle</button>
-            <button @click="setDrawingMode('circle')">Circle</button>
-            <button @click="deleteSelection()">Delete</button>
-            <button @click="mapMode='ready'">Save</button>
-          </div>
+          <template v-slot="on">
+            <drawing-toolbar
+              @drawingmode_changed="on.setDrawingMode($event)"
+              @delete_selection="on.deleteSelection()"
+              @save="mapMode='ready'"
+            />
+          </template>
         </gmap-drawing-manager>
       </template>
     </gmap-map>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
+    const toolbarTemplate =
+      '<div style="background-color: #040404; display: flex; position: absolute; padding: 8px">' +
+      "  <div><button @click=\"$emit('drawingmode_changed', 'rectangle')\">Rectangle</button></div>" +
+      "  <div><button @click=\"$emit('drawingmode_changed', 'circle')\">Circle</button></div>" +
+      "  <div><button @click=\"$emit('drawingmode_changed', 'polyline')\">Line</button></div>" +
+      "  <div><button @click=\"$emit('drawingmode_changed', 'polygon')\">Polygon</button></div>" +
+      "  <div><button @click=\"$emit('delete_selection')\">Delete</button></div>" +
+      "  <div><button @click=\"$emit('save')\">Save</button></div>" +
+      "</div>";
+
     Vue.use(GmapVue, {
       load: {
-        key: "AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc",
-        libraries: "places,drawing",
-      },
+        key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
+        libraries: 'places,drawing'
+      }
     });
 
-    document.addEventListener("DOMContentLoaded", function () {
+    document.addEventListener('DOMContentLoaded', function() {
       new Vue({
-        el: "#root",
+        el: '#root',
+        components: {
+          drawingToolbar: {
+            template: toolbarTemplate
+          }
+        },
         data: {
-          mapCenter: { lat: 0, lng: 0 },
+          mapCenter: { lat: 4.5, lng: 99 },
           mapMode: null,
           mapDraggable: true,
           mapCursor: null,
           shapes: [],
           rectangleOptions: {
-            fillColor: "#777",
+            fillColor: '#777',
             fillOpacity: 0.4,
             strokeWeight: 2,
-            strokeColor: "#999",
+            strokeColor: '#999',
             draggable: false,
             editable: false,
-            clickable: true,
+            clickable: true
           },
           circleOptions: {
-            fillColor: "#777",
+            fillColor: '#777',
             fillOpacity: 0.4,
             strokeWeight: 2,
-            strokeColor: "#999",
+            strokeColor: '#999',
             draggable: false,
             editable: false,
-            clickable: true,
+            clickable: true
           },
+          polylineOptions: {
+            fillColor: '#777',
+            fillOpacity: 0.4,
+            strokeWeight: 2,
+            strokeColor: '#999',
+            draggable: false,
+            editable: false,
+            clickable: true
+          },
+          polygonOptions: {
+            fillColor: '#777',
+            fillOpacity: 0.4,
+            strokeWeight: 2,
+            strokeColor: '#999',
+            draggable: false,
+            editable: false,
+            clickable: true
+          }
         },
         watch: {
           mapMode(newMode, oldMode) {
-            if (newMode === "ready") {
-              if (oldMode === "edit") {
+            if (newMode === 'ready') {
+              if (oldMode === 'edit') {
                 this.mapDraggable = true;
                 this.mapCursor = null;
                 return;
               }
             }
 
-            if (newMode === "edit") {
+            if (newMode === 'edit') {
               this.mapDraggable = false;
-              this.mapCursor = "default";
+              this.mapCursor = 'default';
             }
-          },
+          }
         },
         mounted() {
-          this.mapMode = "ready";
-        },
-        methods: {},
+          this.mapMode = 'ready';
+        }
       });
     });
   </script>

--- a/packages/documentation/docs/examples/drawing-manager.md
+++ b/packages/documentation/docs/examples/drawing-manager.md
@@ -10,10 +10,10 @@
 <body>
   <div id="root">
     <h1>Drawing Manager Example</h1>
-    <div style="width: 100%;">
-      <span style="width: auto;" />
+    <div style="width:100%; display: flex; justify-content: center;">
+      <span style="width:auto" />
       {{ mapMode }} - {{ toolbarPosition }}
-      <span style="width: auto;" />
+      <span style="width:auto" />
       <button @click="setPos">Position</button>
       <button @click="mapMode='edit'">Edit</button>
     </div>
@@ -21,20 +21,20 @@
     <gmap-map
       ref="mapRef"
       :center="mapCenter"
-      :zoom="17"
+      :zoom="7"
       map-type-id="roadmap"
-      style="width: 100%; height: 100%;"
+      style="width: 100%; height: 800px"
       :options="{
-	      zoomControl: true,
-	      mapTypeControl: true,
-	      scaleControl: false,
-	      streetViewControl: false,
-	      rotateControl: false,
-	      fullscreenControl: false,
-	      disableDefaultUi: false,
-	      draggable: mapDraggable,
-	      draggableCursor: mapCursor
-	    }"
+          zoomControl: true,
+          mapTypeControl: true,
+          scaleControl: false,
+          streetViewControl: false,
+          rotateControl: false,
+          fullscreenControl: false,
+          disableDefaultUi: false,
+          draggable: mapDraggable,
+          draggableCursor: mapCursor
+        }"
     >
       <template #visible>
         <gmap-drawing-manager
@@ -49,95 +49,95 @@
     </gmap-map>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {
       load: {
-        key: "AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc",
-        libraries: "places,drawing",
-      },
+        key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
+        libraries: 'places,drawing'
+      }
     });
 
-    document.addEventListener("DOMContentLoaded", function () {
+    document.addEventListener('DOMContentLoaded', function() {
       new Vue({
-        el: "#root",
+        el: '#root',
         data: {
-          mapCenter: { lat: 0, lng: 0 },
+          mapCenter: { lat: 4.5, lng: 99 },
           mapMode: null,
-          toolbarPosition: "TOP_CENTER",
+          toolbarPosition: 'TOP_CENTER',
           mapDraggable: true,
           mapCursor: null,
           shapes: [],
           rectangleOptions: {
-            fillColor: "#777",
+            fillColor: '#777',
             fillOpacity: 0.4,
             strokeWeight: 2,
-            strokeColor: "#999",
+            strokeColor: '#999',
             draggable: false,
             editable: false,
-            clickable: true,
+            clickable: true
           },
           circleOptions: {
-            fillColor: "#777",
+            fillColor: '#777',
             fillOpacity: 0.4,
             strokeWeight: 2,
-            strokeColor: "#999",
+            strokeColor: '#999',
             draggable: false,
             editable: false,
-            clickable: true,
+            clickable: true
           },
           polylineOptions: {
-            fillColor: "#777",
+            fillColor: '#777',
             fillOpacity: 0.4,
             strokeWeight: 2,
-            strokeColor: "#999",
+            strokeColor: '#999',
             draggable: false,
             editable: false,
-            clickable: true,
-          },
+            clickable: true
+          }
         },
         watch: {
           mapMode(newMode, oldMode) {
-            if (newMode === "ready") {
-              if (oldMode === "edit") {
+            if (newMode === 'ready') {
+              if (oldMode === 'edit') {
                 this.mapDraggable = true;
                 this.mapCursor = null;
                 return;
               }
             }
 
-            if (newMode === "edit") {
+            if (newMode === 'edit') {
               this.mapDraggable = false;
-              this.mapCursor = "default";
+              this.mapCursor = 'default';
             }
-          },
+          }
         },
         mounted() {
-          this.mapMode = "ready";
+          this.mapMode = 'ready';
         },
         methods: {
           setPos() {
             const posTypes = [
-              "TOP_CENTER",
-              "TOP_LEFT",
-              "TOP_RIGHT",
-              "LEFT_TOP",
-              "RIGHT_TOP",
-              "LEFT_CENTER",
-              "RIGHT_CENTER",
-              "LEFT_BOTTOM",
-              "RIGHT_BOTTOM",
-              "BOTTOM_CENTER",
-              "BOTTOM_LEFT",
-              "BOTTOM_RIGHT",
+              'TOP_CENTER',
+              'TOP_LEFT',
+              'TOP_RIGHT',
+              'LEFT_TOP',
+              'RIGHT_TOP',
+              'LEFT_CENTER',
+              'RIGHT_CENTER',
+              'LEFT_BOTTOM',
+              'RIGHT_BOTTOM',
+              'BOTTOM_CENTER',
+              'BOTTOM_LEFT',
+              'BOTTOM_RIGHT'
             ];
 
             this.toolbarPosition =
               posTypes[Math.floor(Math.random() * posTypes.length)];
-          },
-        },
+          }
+        }
       });
     });
   </script>

--- a/packages/documentation/docs/examples/heat-map-layer.md
+++ b/packages/documentation/docs/examples/heat-map-layer.md
@@ -9,10 +9,6 @@
 ```html
 <body>
   <div id="root">
-    <button @click="setMarkers">
-      Set markers on heatmap
-    </button>
-    <br /><br />
     <gmap-map
       ref="mapRef"
       :zoom="7"
@@ -35,42 +31,41 @@
     </gmap-map>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {
       load: {
-        key: "AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc",
-        libraries: "visualization",
-      },
+        key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
+        libraries: 'visualization'
+      }
     });
 
-    document.addEventListener("DOMContentLoaded", function () {
+    document.addEventListener('DOMContentLoaded', function() {
       new Vue({
-        el: "#root",
+        el: '#root',
         data: {
           center: { lat: 4.5, lng: 99 },
           markers: [],
         },
-        methods: {
-          setMarkers() {
-            this.markers = [
-              {
-                location: new google.maps.LatLng({ lat: 3, lng: 101 }),
-                weight: 100,
-              },
-              {
-                location: new google.maps.LatLng({ lat: 5, lng: 99 }),
-                weight: 50,
-              },
-              {
-                location: new google.maps.LatLng({ lat: 6, lng: 97 }),
-                weight: 80,
-              },
-            ];
-          },
-        },
+        async mounted() {
+          await this.$gmapApiPromiseLazy();
+          this.markers = [
+            {
+              location: new google.maps.LatLng({ lat: 3, lng: 101 }),
+              weight: 100
+            },
+            {
+              location: new google.maps.LatLng({ lat: 5, lng: 99 }),
+              weight: 50
+            },
+            {
+              location: new google.maps.LatLng({ lat: 6, lng: 97 }),
+              weight: 80
+            }
+          ];
+        }
       });
     });
   </script>

--- a/packages/documentation/docs/examples/kml-layer.md
+++ b/packages/documentation/docs/examples/kml-layer.md
@@ -15,7 +15,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/map-center-twoway.md
+++ b/packages/documentation/docs/examples/map-center-twoway.md
@@ -73,7 +73,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/map-center.md
+++ b/packages/documentation/docs/examples/map-center.md
@@ -150,7 +150,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/map-destroy.md
+++ b/packages/documentation/docs/examples/map-destroy.md
@@ -41,7 +41,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/map-functions.md
+++ b/packages/documentation/docs/examples/map-functions.md
@@ -27,7 +27,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/map-type-id.md
+++ b/packages/documentation/docs/examples/map-type-id.md
@@ -19,7 +19,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/marker.md
+++ b/packages/documentation/docs/examples/marker.md
@@ -15,7 +15,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/overlay.md
+++ b/packages/documentation/docs/examples/overlay.md
@@ -22,7 +22,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/place-default.md
+++ b/packages/documentation/docs/examples/place-default.md
@@ -17,7 +17,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.6/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/place-input.md
+++ b/packages/documentation/docs/examples/place-input.md
@@ -23,7 +23,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.10/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/polygon-advanced.md
+++ b/packages/documentation/docs/examples/polygon-advanced.md
@@ -44,7 +44,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/polygon-simple.md
+++ b/packages/documentation/docs/examples/polygon-simple.md
@@ -26,7 +26,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/polyline.md
+++ b/packages/documentation/docs/examples/polyline.md
@@ -31,7 +31,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/resize-bus.md
+++ b/packages/documentation/docs/examples/resize-bus.md
@@ -51,7 +51,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/status-bar-information.md
+++ b/packages/documentation/docs/examples/status-bar-information.md
@@ -37,7 +37,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/street-view-panorama.md
+++ b/packages/documentation/docs/examples/street-view-panorama.md
@@ -62,7 +62,7 @@ Experimental
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/docs/examples/window-information.md
+++ b/packages/documentation/docs/examples/window-information.md
@@ -20,7 +20,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.1/dist/gmap-vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>
     Vue.use(GmapVue, {

--- a/packages/documentation/package-lock.json
+++ b/packages/documentation/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "docs",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "documentation of vue2=google-maps",
   "main": "index.js",
   "author": "Diego A. Zapata Hantsch",

--- a/packages/gmap-vue/examples/autocomplete.html
+++ b/packages/gmap-vue/examples/autocomplete.html
@@ -18,12 +18,12 @@
     </Gmap-Map>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
   <script src="gmap-vue.js"></script>
 
   <script>
 
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
         libraries: 'places'

--- a/packages/gmap-vue/examples/basic-autocomplete.html
+++ b/packages/gmap-vue/examples/basic-autocomplete.html
@@ -28,13 +28,13 @@
     </div>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
 
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
         libraries: 'places'

--- a/packages/gmap-vue/examples/basic-kml-layer.html
+++ b/packages/gmap-vue/examples/basic-kml-layer.html
@@ -6,10 +6,10 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc'
       },
@@ -18,8 +18,8 @@
     });
 
     document.addEventListener('DOMContentLoaded', function () {
-      Vue.component('google-map', VueGoogleMaps.Map);
-      Vue.component('google-kml-layer', VueGoogleMaps.KmlLayer);
+      Vue.component('google-map', GmapVue.Map);
+      Vue.component('google-kml-layer', GmapVue.KmlLayer);
 
       new Vue({
         el: '#root',

--- a/packages/gmap-vue/examples/basic-map-functions.html
+++ b/packages/gmap-vue/examples/basic-map-functions.html
@@ -18,10 +18,10 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc'
       },

--- a/packages/gmap-vue/examples/basic-marker-clusterer.html
+++ b/packages/gmap-vue/examples/basic-marker-clusterer.html
@@ -14,10 +14,10 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/markerclustererplus/2.1.4/markerclusterer.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc'
       },
@@ -25,7 +25,7 @@
 
     document.addEventListener('DOMContentLoaded', function() {
       // gmapCluster *must* be manually imported
-      Vue.component('gmap-cluster', VueGoogleMaps.Cluster);
+      Vue.component('gmap-cluster', GmapVue.Cluster);
 
       new Vue({
         el: '#root',

--- a/packages/gmap-vue/examples/basic-marker-shape.html
+++ b/packages/gmap-vue/examples/basic-marker-shape.html
@@ -10,10 +10,10 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>
-  <script src="../dist/vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc'
       },
@@ -22,8 +22,8 @@
     });
 
     document.addEventListener('DOMContentLoaded', function() {
-      Vue.component('google-map', VueGoogleMaps.Map);
-      Vue.component('google-marker', VueGoogleMaps.Marker);
+      Vue.component('google-map', GmapVue.Map);
+      Vue.component('google-marker', GmapVue.Marker);
 
       new Vue({
         el: '#root',

--- a/packages/gmap-vue/examples/basic-marker.html
+++ b/packages/gmap-vue/examples/basic-marker.html
@@ -6,10 +6,10 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc'
       },
@@ -18,8 +18,8 @@
     });
 
     document.addEventListener('DOMContentLoaded', function() {
-      Vue.component('google-map', VueGoogleMaps.Map);
-      Vue.component('google-marker', VueGoogleMaps.Marker);
+      Vue.component('google-map', GmapVue.Map);
+      Vue.component('google-marker', GmapVue.Marker);
 
       new Vue({
         el: '#root',

--- a/packages/gmap-vue/examples/basic-place-input.html
+++ b/packages/gmap-vue/examples/basic-place-input.html
@@ -14,11 +14,11 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.10/vue.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-<script src="vue-google-maps.js"></script>
+<script src="gmap-vue.js"></script>
 
 <script>
 
-Vue.use(VueGoogleMaps, {
+Vue.use(GmapVue, {
   load: {
     key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
     libraries: 'places'

--- a/packages/gmap-vue/examples/default-place.html
+++ b/packages/gmap-vue/examples/default-place.html
@@ -8,10 +8,10 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.1.6/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
         libraries: 'places'

--- a/packages/gmap-vue/examples/drawing-manager.html
+++ b/packages/gmap-vue/examples/drawing-manager.html
@@ -1,7 +1,7 @@
 <body>
   <div id="root">
     <h1>Drawing Manager Example</h1>
-    <div style="width:100%">
+    <div style="width:100%; display: flex; justify-content: center;">
       <span style="width:auto" />
       {{ mapMode }} - {{ toolbarPosition }}
       <span style="width:auto" />
@@ -9,129 +9,127 @@
       <button @click="mapMode='edit'">Edit</button>
     </div>
     <br />
-	  <gmap-map
-	    ref="mapRef"
-	    :center="mapCenter"
-	    :zoom="17"
-	    map-type-id="roadmap"
-	    style="width: 100%; height: 100%"
-	    :options="{
-	      zoomControl: true,
-	      mapTypeControl: true,
-	      scaleControl: false,
-	      streetViewControl: false,
-	      rotateControl: false,
-	      fullscreenControl: false,
-	      disableDefaultUi: false,
-	      draggable: mapDraggable,
-	      draggableCursor: mapCursor
-	    }"
-	  >
-	    <template #visible>
-	      <gmap-drawing-manager
-	        v-if="mapMode==='edit'"
-	        :position="toolbarPosition"
-	        :rectangle-options="rectangleOptions"
-	        :circle-options="circleOptions"
-	        :polyline-options="polylineOptions"
-	        :shapes="shapes"
-	      />
-	    </template>
-	  </gmap-map>
+    <gmap-map
+      ref="mapRef"
+      :center="mapCenter"
+      :zoom="7"
+      map-type-id="roadmap"
+      style="width: 100%; height: 800px"
+      :options="{
+          zoomControl: true,
+          mapTypeControl: true,
+          scaleControl: false,
+          streetViewControl: false,
+          rotateControl: false,
+          fullscreenControl: false,
+          disableDefaultUi: false,
+          draggable: mapDraggable,
+          draggableCursor: mapCursor
+        }"
+    >
+      <template #visible>
+        <gmap-drawing-manager
+          v-if="mapMode==='edit'"
+          :position="toolbarPosition"
+          :rectangle-options="rectangleOptions"
+          :circle-options="circleOptions"
+          :polyline-options="polylineOptions"
+          :shapes="shapes"
+        />
+      </template>
+    </gmap-map>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
   <script src="gmap-vue.js"></script>
 
   <script>
-
     Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
         libraries: 'places,drawing'
-      },
+      }
     });
 
-    document.addEventListener('DOMContentLoaded', function () {
+    document.addEventListener('DOMContentLoaded', function() {
       new Vue({
         el: '#root',
         data: {
-			mapCenter: {lat: 0, lng: 0},
-			mapMode: null,
-			toolbarPosition: 'TOP_CENTER',
-		    mapDraggable: true,
-		    mapCursor: null,
-		    shapes: [],
-		    rectangleOptions: {
-		      fillColor: '#777',
-		      fillOpacity: 0.4,
-		      strokeWeight: 2,
-		      strokeColor: '#999',
-		      draggable: false,
-		      editable: false,
-		      clickable: true
-		    },
-		    circleOptions: {
-		      fillColor: '#777',
-		      fillOpacity: 0.4,
-		      strokeWeight: 2,
-		      strokeColor: '#999',
-		      draggable: false,
-		      editable: false,
-		      clickable: true
-		    },
-		    polylineOptions: {
-		      fillColor: '#777',
-		      fillOpacity: 0.4,
-		      strokeWeight: 2,
-		      strokeColor: '#999',
-		      draggable: false,
-		      editable: false,
-		      clickable: true
-		    }
+          mapCenter: { lat: 4.5, lng: 99 },
+          mapMode: null,
+          toolbarPosition: 'TOP_CENTER',
+          mapDraggable: true,
+          mapCursor: null,
+          shapes: [],
+          rectangleOptions: {
+            fillColor: '#777',
+            fillOpacity: 0.4,
+            strokeWeight: 2,
+            strokeColor: '#999',
+            draggable: false,
+            editable: false,
+            clickable: true
+          },
+          circleOptions: {
+            fillColor: '#777',
+            fillOpacity: 0.4,
+            strokeWeight: 2,
+            strokeColor: '#999',
+            draggable: false,
+            editable: false,
+            clickable: true
+          },
+          polylineOptions: {
+            fillColor: '#777',
+            fillOpacity: 0.4,
+            strokeWeight: 2,
+            strokeColor: '#999',
+            draggable: false,
+            editable: false,
+            clickable: true
+          }
         },
-		watch: {
-			mapMode (newMode, oldMode) {
-				if (newMode === 'ready') {
-					if (oldMode === 'edit') {
-						this.mapDraggable = true;
-						this.mapCursor = null;
-						return;
-					}
-				}
+        watch: {
+          mapMode(newMode, oldMode) {
+            if (newMode === 'ready') {
+              if (oldMode === 'edit') {
+                this.mapDraggable = true;
+                this.mapCursor = null;
+                return;
+              }
+            }
 
-				if (newMode === 'edit') {
-					this.mapDraggable = false;
-					this.mapCursor = 'default';
-				}
-			}
-		},
-		mounted () {
-			this.mapMode = 'ready';
-		},
+            if (newMode === 'edit') {
+              this.mapDraggable = false;
+              this.mapCursor = 'default';
+            }
+          }
+        },
+        mounted() {
+          this.mapMode = 'ready';
+        },
         methods: {
-		    setPos () {
-		      const posTypes = [
-		        'TOP_CENTER',
-		        'TOP_LEFT',
-		        'TOP_RIGHT',
-		        'LEFT_TOP',
-		        'RIGHT_TOP',
-		        'LEFT_CENTER',
-		        'RIGHT_CENTER',
-		        'LEFT_BOTTOM',
-		        'RIGHT_BOTTOM',
-		        'BOTTOM_CENTER',
-		        'BOTTOM_LEFT',
-		        'BOTTOM_RIGHT'
-		      ];
-		
-		      this.toolbarPosition = posTypes[Math.floor(Math.random() * posTypes.length)];
-		    }
+          setPos() {
+            const posTypes = [
+              'TOP_CENTER',
+              'TOP_LEFT',
+              'TOP_RIGHT',
+              'LEFT_TOP',
+              'RIGHT_TOP',
+              'LEFT_CENTER',
+              'RIGHT_CENTER',
+              'LEFT_BOTTOM',
+              'RIGHT_BOTTOM',
+              'BOTTOM_CENTER',
+              'BOTTOM_LEFT',
+              'BOTTOM_RIGHT'
+            ];
+
+            this.toolbarPosition =
+              posTypes[Math.floor(Math.random() * posTypes.length)];
+          }
         }
       });
     });
-
   </script>
-
 </body>

--- a/packages/gmap-vue/examples/drawing-manager2.html
+++ b/packages/gmap-vue/examples/drawing-manager2.html
@@ -1,111 +1,144 @@
 <body>
   <div id="root">
     <h1>Drawing Manager Example</h1>
-    <div style="width:100%">
+    <div style="width:100%; display: flex; justify-content: center;">
       <span style="width:auto" />
       {{ mapMode }}
       <span style="width:auto" />
       <button @click="mapMode='edit'">Edit</button>
     </div>
     <br />
-	  <gmap-map
-	    ref="mapRef"
-	    :center="mapCenter"
-	    :zoom="17"
-	    map-type-id="roadmap"
-	    style="width: 100%; height: 100%"
-	    :options="{
-	      zoomControl: true,
-	      mapTypeControl: true,
-	      scaleControl: false,
-	      streetViewControl: false,
-	      rotateControl: false,
-	      fullscreenControl: false,
-	      disableDefaultUi: false,
-	      draggable: mapDraggable,
-	      draggableCursor: mapCursor
-	    }"
-	  >
-	    <template #visible>
-	      <gmap-drawing-manager
-	        v-if="mapMode==='edit'"
-	        :rectangle-options="rectangleOptions"
-	        :circle-options="circleOptions"
-	        :shapes="shapes"
-	      >
-			  <div>
-			    <button @click="setDrawingMode('rectangle')">Rectangle</button>
-			    <button @click="setDrawingMode('circle')">Circle</button>
-			    <button @click="deleteSelection()">Delete</button>
-			    <button @click="mapMode='ready'">Save</button>
-			  </div>
-	      </gmap-drawing-manager>
-	    </template>
-	  </gmap-map>
+    <gmap-map
+      ref="mapRef"
+      :center="mapCenter"
+      :zoom="7"
+      map-type-id="roadmap"
+      style="width: 100%; height: 800px; display:flex; justify-content: center; align-items: flex-start;"
+      :options="{
+          zoomControl: true,
+          mapTypeControl: true,
+          scaleControl: false,
+          streetViewControl: false,
+          rotateControl: false,
+          fullscreenControl: false,
+          disableDefaultUi: false,
+          draggable: mapDraggable,
+          draggableCursor: mapCursor
+        }"
+    >
+      <template #visible>
+        <gmap-drawing-manager
+          v-if="mapMode==='edit'"
+          :rectangle-options="rectangleOptions"
+          :circle-options="circleOptions"
+          :polyline-options="polylineOptions"
+          :polygon-options="polygonOptions"
+          :shapes="shapes"
+        >
+          <template v-slot="on">
+            <drawing-toolbar
+              @drawingmode_changed="on.setDrawingMode($event)"
+              @delete_selection="on.deleteSelection()"
+              @save="mapMode='ready'"
+            />
+          </template>
+        </gmap-drawing-manager>
+      </template>
+    </gmap-map>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
   <script src="gmap-vue.js"></script>
 
   <script>
+    const toolbarTemplate =
+      '<div style="background-color: #040404; display: flex; position: absolute; padding: 8px">' +
+      "  <div><button @click=\"$emit('drawingmode_changed', 'rectangle')\">Rectangle</button></div>" +
+      "  <div><button @click=\"$emit('drawingmode_changed', 'circle')\">Circle</button></div>" +
+      "  <div><button @click=\"$emit('drawingmode_changed', 'polyline')\">Line</button></div>" +
+      "  <div><button @click=\"$emit('drawingmode_changed', 'polygon')\">Polygon</button></div>" +
+      "  <div><button @click=\"$emit('delete_selection')\">Delete</button></div>" +
+      "  <div><button @click=\"$emit('save')\">Save</button></div>" +
+      "</div>";
 
     Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
         libraries: 'places,drawing'
-      },
+      }
     });
 
-    document.addEventListener('DOMContentLoaded', function () {
+    document.addEventListener('DOMContentLoaded', function() {
       new Vue({
         el: '#root',
+        components: {
+          drawingToolbar: {
+            template: toolbarTemplate
+          }
+        },
         data: {
-			mapCenter: {lat: 0, lng: 0},
-			mapMode: null,
-		    mapDraggable: true,
-		    mapCursor: null,
-		    shapes: [],
-		    rectangleOptions: {
-		      fillColor: '#777',
-		      fillOpacity: 0.4,
-		      strokeWeight: 2,
-		      strokeColor: '#999',
-		      draggable: false,
-		      editable: false,
-		      clickable: true
-		    },
-		    circleOptions: {
-		      fillColor: '#777',
-		      fillOpacity: 0.4,
-		      strokeWeight: 2,
-		      strokeColor: '#999',
-		      draggable: false,
-		      editable: false,
-		      clickable: true
-		    },
+          mapCenter: { lat: 4.5, lng: 99 },
+          mapMode: null,
+          mapDraggable: true,
+          mapCursor: null,
+          shapes: [],
+          rectangleOptions: {
+            fillColor: '#777',
+            fillOpacity: 0.4,
+            strokeWeight: 2,
+            strokeColor: '#999',
+            draggable: false,
+            editable: false,
+            clickable: true
+          },
+          circleOptions: {
+            fillColor: '#777',
+            fillOpacity: 0.4,
+            strokeWeight: 2,
+            strokeColor: '#999',
+            draggable: false,
+            editable: false,
+            clickable: true
+          },
+          polylineOptions: {
+            fillColor: '#777',
+            fillOpacity: 0.4,
+            strokeWeight: 2,
+            strokeColor: '#999',
+            draggable: false,
+            editable: false,
+            clickable: true
+          },
+          polygonOptions: {
+            fillColor: '#777',
+            fillOpacity: 0.4,
+            strokeWeight: 2,
+            strokeColor: '#999',
+            draggable: false,
+            editable: false,
+            clickable: true
+          }
         },
         watch: {
           mapMode(newMode, oldMode) {
-            if (newMode === "ready") {
-              if (oldMode === "edit") {
+            if (newMode === 'ready') {
+              if (oldMode === 'edit') {
                 this.mapDraggable = true;
                 this.mapCursor = null;
                 return;
               }
             }
 
-            if (newMode === "edit") {
+            if (newMode === 'edit') {
               this.mapDraggable = false;
-              this.mapCursor = "default";
+              this.mapCursor = 'default';
             }
-          },
+          }
         },
         mounted() {
-          this.mapMode = "ready";
-        },
-        methods: {},
+          this.mapMode = 'ready';
+        }
       });
     });
   </script>
-
 </body>

--- a/packages/gmap-vue/examples/heatmap-layer.html
+++ b/packages/gmap-vue/examples/heatmap-layer.html
@@ -1,15 +1,11 @@
 <body>
   <div id="root">
-    <button @click="setMarkers">
-      Set markers on heatmap
-    </button>
-    <br /><br />
     <gmap-map
       ref="mapRef"
       :zoom="7"
       :center="center"
       map-type-id="roadmap"
-      style="width: 100%; height: 500px;"
+      style="width: 100%; height: 500px"
     >
       <gmap-marker
         v-for="(m, index) in markers"
@@ -26,42 +22,41 @@
     </gmap-map>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
   <script src="gmap-vue.js"></script>
 
   <script>
     Vue.use(GmapVue, {
       load: {
-        key: "AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc",
-        libraries: "visualization",
-      },
+        key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
+        libraries: 'visualization'
+      }
     });
 
-    document.addEventListener("DOMContentLoaded", function () {
+    document.addEventListener('DOMContentLoaded', function() {
       new Vue({
-        el: "#root",
+        el: '#root',
         data: {
           center: { lat: 4.5, lng: 99 },
           markers: [],
         },
-        methods: {
-          setMarkers() {
-            this.markers = [
-              {
-                location: new google.maps.LatLng({ lat: 3, lng: 101 }),
-                weight: 100,
-              },
-              {
-                location: new google.maps.LatLng({ lat: 5, lng: 99 }),
-                weight: 50,
-              },
-              {
-                location: new google.maps.LatLng({ lat: 6, lng: 97 }),
-                weight: 80,
-              },
-            ];
-          },
-        },
+        async mounted() {
+          await this.$gmapApiPromiseLazy();
+          this.markers = [
+            {
+              location: new google.maps.LatLng({ lat: 3, lng: 101 }),
+              weight: 100
+            },
+            {
+              location: new google.maps.LatLng({ lat: 5, lng: 99 }),
+              weight: 50
+            },
+            {
+              location: new google.maps.LatLng({ lat: 6, lng: 97 }),
+              weight: 80
+            }
+          ];
+        }
       });
     });
   </script>

--- a/packages/gmap-vue/examples/info-bar.html
+++ b/packages/gmap-vue/examples/info-bar.html
@@ -31,11 +31,11 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-<script src="vue-google-maps.js"></script>
+<script src="gmap-vue.js"></script>
 
 <script>
 
-Vue.use(VueGoogleMaps, {
+Vue.use(GmapVue, {
   load: {
     key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc'
   },

--- a/packages/gmap-vue/examples/infowindow.html
+++ b/packages/gmap-vue/examples/infowindow.html
@@ -11,10 +11,10 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc'
       },
@@ -33,7 +33,7 @@
           currentMidx: null,
 
           infoOptions: {
-        	content: '',
+            content: '',
             //optional: offset infowindow so it visually sits nicely on top of our marker
             pixelOffset: {
               width: 0,

--- a/packages/gmap-vue/examples/maptypeid.html
+++ b/packages/gmap-vue/examples/maptypeid.html
@@ -12,10 +12,10 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc'
       },

--- a/packages/gmap-vue/examples/overlay.html
+++ b/packages/gmap-vue/examples/overlay.html
@@ -12,10 +12,10 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
         v: '3.26',
@@ -25,8 +25,8 @@
     });
 
     document.addEventListener('DOMContentLoaded', function() {
-      Vue.component('google-map', VueGoogleMaps.Map);
-      Vue.component('ground-overlay', VueGoogleMaps.MapElementFactory({
+      Vue.component('google-map', GmapVue.Map);
+      Vue.component('ground-overlay', GmapVue.MapElementFactory({
         mappedProps: {
           'opacity': {}
         },

--- a/packages/gmap-vue/examples/polygon-editing-geojson.html
+++ b/packages/gmap-vue/examples/polygon-editing-geojson.html
@@ -30,10 +30,10 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
         libraries: 'places',

--- a/packages/gmap-vue/examples/polygon-editing.html
+++ b/packages/gmap-vue/examples/polygon-editing.html
@@ -17,10 +17,10 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc'
       },

--- a/packages/gmap-vue/examples/polyline-editing.html
+++ b/packages/gmap-vue/examples/polyline-editing.html
@@ -25,10 +25,10 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
         libraries: 'places',

--- a/packages/gmap-vue/examples/resize-bus-destroy.html
+++ b/packages/gmap-vue/examples/resize-bus-destroy.html
@@ -32,11 +32,11 @@
   </div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-<script src="vue-google-maps.js"></script>
+<script src="gmap-vue.js"></script>
 
 <script>
 
-Vue.use(VueGoogleMaps, {
+Vue.use(GmapVue, {
   load: {
     key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
   },

--- a/packages/gmap-vue/examples/resize-bus.html
+++ b/packages/gmap-vue/examples/resize-bus.html
@@ -42,11 +42,11 @@
   </div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
-<script src="vue-google-maps.js"></script>
+<script src="gmap-vue.js"></script>
 
 <script>
 
-Vue.use(VueGoogleMaps, {
+Vue.use(GmapVue, {
   load: {
     key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
   },

--- a/packages/gmap-vue/examples/src/ExamplesMain.js
+++ b/packages/gmap-vue/examples/src/ExamplesMain.js
@@ -3,12 +3,12 @@ import ExamplePageDefault from './ExamplePageDefault.vue'
 import ExamplePage from './ExamplePage.vue'
 import Examples from '../examples-index'
 import Vue from 'vue'
-import * as VueGoogleMaps from '../../dist/main.js'
+import * as GmapVue from '../../dist/main.js'
 import VueRouter from 'vue-router'
 
 Vue.config.optionMergeStrategies.description = (a, b) => a || b
 
-Vue.use(VueGoogleMaps, {
+Vue.use(GmapVue, {
   load: {
     key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
     libraries: 'places'

--- a/packages/gmap-vue/examples/src/auto/manualDoc.yml
+++ b/packages/gmap-vue/examples/src/auto/manualDoc.yml
@@ -9,7 +9,7 @@
 #     <p>For example to wrap around the <code>GroundOverlay</code>
 #     class, one would write something like:</p>
 #     <pre>
-#     Vue.component('ground-overlay', VueGoogleMaps.MapElementFactory({
+#     Vue.component('ground-overlay', GmapVue.MapElementFactory({
 #       mappedProps: {
 #         'opacity': {}
 #       },

--- a/packages/gmap-vue/examples/src/main.js
+++ b/packages/gmap-vue/examples/src/main.js
@@ -1,8 +1,8 @@
 import Vue from 'vue/dist/vue.js'
 import App from './app.vue'
-import * as VueGoogleMaps from '../../src/main.js'
+import * as GmapVue from '../../src/main.js'
 
-Vue.use(VueGoogleMaps, {
+Vue.use(GmapVue, {
   installComponents: true,
   load: {
     key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
@@ -13,6 +13,8 @@ Vue.use(VueGoogleMaps, {
 // json filter is now not bundled with vue
 Vue.filter('json', x => JSON.stringify(x))
 
+// TODO: Should be analyzed when we start with the test issue
+// eslint-disable-next-line no-new
 new Vue({
   el: '#root',
   components: {

--- a/packages/gmap-vue/examples/street-view-pano.html
+++ b/packages/gmap-vue/examples/street-view-pano.html
@@ -24,10 +24,10 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
         libraries: 'places'

--- a/packages/gmap-vue/examples/test-map-center-twoway.html
+++ b/packages/gmap-vue/examples/test-map-center-twoway.html
@@ -52,10 +52,10 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
       }

--- a/packages/gmap-vue/examples/test-map-center.html
+++ b/packages/gmap-vue/examples/test-map-center.html
@@ -114,17 +114,17 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.0/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.16.4/lodash.js"></script>
-  <script src="vue-google-maps.js"></script>
+  <script src="gmap-vue.js"></script>
 
   <script>
-    Vue.use(VueGoogleMaps, {
+    Vue.use(GmapVue, {
       load: {
         key: 'AIzaSyDf43lPdwlF98RCBsJOFNKOkoEjkwxb5Sc',
       }
     });
 
     document.addEventListener('DOMContentLoaded', function() {
-      Vue.component('google-map', VueGoogleMaps.Map);
+      Vue.component('google-map', GmapVue.Map);
 
       for (let test of tests) {
         test();

--- a/packages/gmap-vue/package-lock.json
+++ b/packages/gmap-vue/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gmap-vue",
-  "version": "1.0.0",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/gmap-vue/package.json
+++ b/packages/gmap-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gmap-vue",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "This is a google map component for Vue.js, updated for Vue 2 compatibility",
   "main": "dist/main.js",
   "scripts": {

--- a/packages/gmap-vue/src/components-implementation/drawing-manager.js
+++ b/packages/gmap-vue/src/components-implementation/drawing-manager.js
@@ -65,6 +65,7 @@ export default mapElementFactory({
         : google.maps.ControlPosition.TOP_LEFT
 
     options.drawingMode = null
+    options.drawingControl = !this.$scopedSlots.default
     options.drawingControlOptions = {
       drawingModes,
       position

--- a/packages/gmap-vue/src/main.js
+++ b/packages/gmap-vue/src/main.js
@@ -31,6 +31,7 @@ const Cluster = (process.env.BUILD_DEV === '1')
   ? undefined
   : ((s) => s.default || s)(require('./components/cluster'))
 
+// TODO: This should be checked if it must be GmapVue, Gmap.api or something else
 let GmapApi = null
 
 // export everything
@@ -51,7 +52,7 @@ export function install (Vue, options) {
   // Update the global `GmapApi`. This will allow
   // components to use the `google` global reactively
   // via:
-  //   import {gmapApi} from 'vue2-google-maps'
+  //   import { gmapApi } from 'gmap-vue'
   //   export default {  computed: { google: gmapApi }  }
   GmapApi = new Vue({ data: { gmapApi: null } })
 

--- a/packages/gmap-vue/test/.eslintrc.js
+++ b/packages/gmap-vue/test/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     ecmaVersion: 6,
     ecmaFeatures: {
       modules: true
-    },
+    }
   },
   env: {
     browser: true,

--- a/packages/gmap-vue/test/test-pages/test-gmapApi.html
+++ b/packages/gmap-vue/test/test-pages/test-gmapApi.html
@@ -16,7 +16,7 @@
     </gmap-map>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
   <script src="../../dist/gmap-vue.js"></script>
 
   <script>
@@ -28,7 +28,7 @@
     document.addEventListener('DOMContentLoaded', () => {
       window.vue = new Vue({
         computed: {
-          google: VueGoogleMaps.gmapApi
+          google: GmapVue.gmapApi
         },
         el: '#test'
       })

--- a/packages/gmap-vue/test/test-pages/test-page-without-maps.html
+++ b/packages/gmap-vue/test/test-pages/test-page-without-maps.html
@@ -15,7 +15,7 @@
     <gmap-map v-if="loadMap" ref="gmap"></gmap-map>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/vue.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
   <script src="../../dist/gmap-vue.js"></script>
 
   <script>


### PR DESCRIPTION
* fix(documentation): change heatmap and drawing map examples

We change examples and fix the drawing-manager.js adding the previously
removed line 68.

close: #44

* docs(documentation): add documentation for lazy loading and slots

close: #44

* docs(documentation): upgrade documentation version and gmap-vue version on examples

* docs(gmap-vue): upgrade gmap-vue version

* test(gmap-vue): fix tests to the new api name

* docs(documentation): add documentation explain how to access google maps api

* chore(all): update package-lock

* chore(root): add script test to travis yaml file