### PR TITLE
feat(gmap-vue): upgrade markerclustererplus

### DIFF
--- a/packages/documentation/docs/examples/basic-marker-cluster.md
+++ b/packages/documentation/docs/examples/basic-marker-cluster.md
@@ -22,7 +22,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/markerclustererplus/2.1.4/markerclusterer.js"></script>
+  <script src="https://unpkg.com/@google/markerclustererplus@5.1.0/dist/markerclustererplus.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
 
   <script>

--- a/packages/documentation/package-lock.json
+++ b/packages/documentation/package-lock.json
@@ -5722,14 +5722,6 @@
 				"slash": "^3.0.0"
 			}
 		},
-		"gmap-vue": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/gmap-vue/-/gmap-vue-1.4.0.tgz",
-			"integrity": "sha512-LTgM0Msfz0OpCaCYTFU8MU0/ELMEW6F4v8pX3slkt2/WYtfGz265MvqGJFa8ho3vuAk33FF5ukRQe9UN9Ynu8A==",
-			"requires": {
-				"marker-clusterer-plus": "^2.1.4"
-			}
-		},
 		"good-listener": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
@@ -7274,11 +7266,6 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz",
 			"integrity": "sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw=="
-		},
-		"marker-clusterer-plus": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz",
-			"integrity": "sha1-+O/3TVmdqzt9Dj/tUmTqDnBPXWc="
 		},
 		"md5.js": {
 			"version": "1.3.5",

--- a/packages/gmap-vue/examples/basic-marker-clusterer.html
+++ b/packages/gmap-vue/examples/basic-marker-clusterer.html
@@ -13,7 +13,7 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/markerclustererplus/2.1.4/markerclusterer.js"></script>
+  <script src="https://unpkg.com/@google/markerclustererplus@5.1.0/dist/markerclustererplus.min.js"></script>
   <script src="gmap-vue.js"></script>
 
   <script>

--- a/packages/gmap-vue/package-lock.json
+++ b/packages/gmap-vue/package-lock.json
@@ -1202,6 +1202,11 @@
         }
       }
     },
+    "@google/markerclustererplus": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@google/markerclustererplus/-/markerclustererplus-5.1.0.tgz",
+      "integrity": "sha512-LLYJHLLERawpRQUn7iu/Y6Ll/2vJct3v5iIky99apzaZ9nTy/adYhAEmnUI9PRnMS3nt65CQdLDz178HA6wvgw=="
+    },
     "@hapi/address": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.1.tgz",
@@ -11285,11 +11290,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
       "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
       "dev": true
-    },
-    "marker-clusterer-plus": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz",
-      "integrity": "sha1-+O/3TVmdqzt9Dj/tUmTqDnBPXWc="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/packages/gmap-vue/package.json
+++ b/packages/gmap-vue/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/diegoazh/gmap-vue#readme",
   "dependencies": {
-    "marker-clusterer-plus": "^2.1.4"
+    "@google/markerclustererplus": "^5.1.0"
   },
   "peerDependencies": {
     "vue": "^2.6.11"

--- a/packages/gmap-vue/src/components/cluster.js
+++ b/packages/gmap-vue/src/components/cluster.js
@@ -7,7 +7,7 @@
   List of properties from
   https://github.com/googlemaps/v3-utility-library/blob/master/markerclustererplus/src/markerclusterer.js
 * */
-import MarkerClusterer from 'marker-clusterer-plus';
+import MarkerClusterer from '@google/markerclustererplus';
 import mapElementFactory from '../factories/map-element';
 
 const props = {
@@ -54,6 +54,10 @@ const props = {
   minimumClusterSize: {
     type: Number,
     twoWay: false,
+  },
+  clusterClass: {
+    type: String,
+    twoWay: false
   },
   styles: {
     type: Array,

--- a/packages/gmap-vue/webpack.config.js
+++ b/packages/gmap-vue/webpack.config.js
@@ -10,7 +10,7 @@ const webConfig = {
   ...config,
   externals: {
     vue: 'Vue',
-    'marker-clusterer-plus': 'MarkerClusterer'
+    '@google/markerclustererplus': 'MarkerClusterer'
   },
   output: {
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
Hello :)

First of all thanks for your work on this project.

But I had a very bad time trying to contribute.
First of all my issue got closed by a bot. I tried again following carefully the template and it happened again. If you look at closed issues, it seems like everybody is struggling with this...
Then I installed the project and ran `npm install`, and surprise, the command builds stuff... Why? I just wanted to install the dependencies.
Then I was not able to commit because of some husky stuff was asking me to set a git user. I never had an issue commiting/pushing to github elsewhere... I ended up doing a `rm .git/hooks/*`.
I feel like this repo has a ton of plugins that explode on your face on every keystroke you make 😅 

Anyway the library is great and I appreciate your work (sorry if I was harsh). Enough whining, here is my PR.

My issue is https://github.com/diegoazh/gmap-vue/issues/80

This PR replaces the `markerclustererplus` package (which was stuck in 2016 in v2.1.4) with `@google/markerclustererplus` which is up to date.
This solves my issue since I needed to set a className on the `styles` prop of the cluster component, which was added in markerclustererplus v5.0.0 (see https://github.com/googlemaps/v3-utility-library/blob/c6b74da7eb6748b404c0174e35d217d973560b09/packages/markerclustererplus/CHANGELOG.md#features-1)
I also added the `clusterClass` prop to the cluster component.

Thanks,