### PR TITLE
feat(gmap-vue): vue3-migrate

### DIFF
--- a/packages/gmap-vue/src/components-implementation/map.js
+++ b/packages/gmap-vue/src/components-implementation/map.js
@@ -53,6 +53,8 @@ const events = [
   'resize',
   'rightclick',
   'tilesloaded',
+  "zoom_changed",
+  "center_changed"
 ];
 
 // Plain Google Maps methods exposed here for convenience
@@ -103,7 +105,7 @@ const recyclePrefix = '__gmc__';
 export default {
   mixins: [mountableMixin],
   props: mappedPropsToVueProps(props),
-
+  emits: events,
   provide() {
     this.$mapPromise = new Promise((resolve, reject) => {
       this.$mapPromiseDeferred = { resolve, reject };

--- a/packages/gmap-vue/src/main.js
+++ b/packages/gmap-vue/src/main.js
@@ -72,9 +72,10 @@ export function install(Vue, options) {
   // via:
   //   import { gmapApi } from 'gmap-vue'
   //   export default {  computed: { google: gmapApi }  }
-  GmapApi = new Vue({ data: { gmapApi: null } });
+  // GmapApi = new Vue({ data: { gmapApi: null } });
+  GmapApi = { gmapApi: null };
 
-  const defaultResizeBus = new Vue();
+  const defaultResizeBus = {};
 
   // Use a lazy to only load the API when
   // a VGM component is loaded

--- a/packages/gmap-vue/src/mixins/map-element.js
+++ b/packages/gmap-vue/src/mixins/map-element.js
@@ -8,9 +8,10 @@
  *
  * */
 export default {
-  inject: {
-    $mapPromise: { default: 'abcdef' },
-  },
+  inject: ['$mapPromise'],
+  // inject: {
+  //   $mapPromise: { default: 'abcdef' },
+  // },
 
   provide() {
     // Note: although this mixin is not "providing" anything,

--- a/packages/gmap-vue/src/utils/bind-events.js
+++ b/packages/gmap-vue/src/utils/bind-events.js
@@ -1,8 +1,7 @@
 export default function bindEvents(vueInst, googleMapsInst, events) {
   events.forEach((eventName) => {
     if (
-      vueInst.$gmapOptions.autobindAllEvents ||
-      vueInst.$listeners[eventName]
+      vueInst.$gmapOptions.autobindAllEvents
     ) {
       googleMapsInst.addListener(eventName, (ev) => {
         vueInst.$emit(eventName, ev);

--- a/packages/gmap-vue/src/utils/bind-props.js
+++ b/packages/gmap-vue/src/utils/bind-props.js
@@ -68,8 +68,7 @@ export function bindProps(vueInst, googleMapsInst, props) {
 
       if (
         twoWay &&
-        (vueInst.$gmapOptions.autobindAllEvents ||
-          vueInst.$listeners[eventName])
+        (vueInst.$gmapOptions.autobindAllEvents)
       ) {
         googleMapsInst.addListener(eventName, () => {
           vueInst.$emit(eventName, googleMapsInst[getMethodName]());

--- a/packages/gmap-vue/src/utils/bind-props.js
+++ b/packages/gmap-vue/src/utils/bind-props.js
@@ -36,7 +36,7 @@ export function bindProps(vueInst, googleMapsInst, props) {
           // eslint-disable-next-line no-underscore-dangle -- old code should be analyzed
           `${setMethodName} is not a method of (the Maps object corresponding to) ${vueInst.$options._componentTag}`
         );
-      }
+      } 
 
       // We need to avoid an endless
       // propChanged -> event emitted -> propChanged -> event emitted loop


### PR DESCRIPTION
Hi there,

These are just some initial, suggested changes for migrating to vue 3.

// install function => main.js
Vue is not constructor but only carries the context of the already created app
Just use normal object for referring to global instance

// $listeners deprecated in vue 3 => map.js
added emits array to map.js

// $listeners deprecated in vue 3 => bind-events.js / bind-props.js
removed second argument in array which interrogates $listeners property

// $mapPromise not available => map-element.js
forced injection of $mapPromise into map-element

Lets discuss :)
Thanks