### PR TITLE
fix(gmap-vue): fix ref conflict on autocomplete component

### DIFF
--- a/packages/documentation/docs/examples/autocomplete.md
+++ b/packages/documentation/docs/examples/autocomplete.md
@@ -96,7 +96,34 @@ The autocomplete supports cutsom text field via scoped slot
         </gmap-autocomplete>
 ```
 
-The ref on the element must be called input, if the element is a vue component then it must have a child ref called input (like in vuetify text-field) or speciy a custom name via childRefName property (only works one level deep into a component).
+The ref on the element must be unique. If you create more than one autocomplete, each one should have a unique ref and it must be mentioned in the slot-ref-name prop. Like this:
+
+```html
+          <gmap-autocomplete class="introInput" >
+                    <template v-slot:input="slotProps">
+                        <v-text-field outlined
+                                      prepend-inner-icon="place"
+                                      placeholder="Location Of Event"
+                                      ref="input"
+                                      v-on:listeners="slotProps.listeners"
+                                      v-on:attrs="slotProps.attrs">
+                        </v-text-field>
+                    </template>
+        </gmap-autocomplete>
+        <gmap-autocomplete class="introInput" slot-ref-name="input2">
+                    <template v-slot:input="slotProps">
+                        <v-text-field outlined
+                                      prepend-inner-icon="place"
+                                      placeholder="Location Of Event"
+                                      ref="input2"
+                                      v-on:listeners="slotProps.listeners"
+                                      v-on:attrs="slotProps.attrs">
+                        </v-text-field>
+                    </template>
+        </gmap-autocomplete>
+```
+
+If the element in the slot is a vue component then it must have a child ref called input (like in vuetify text-field) or specify a custom name via the child-ref-name prop (only works one level deep into a component).
 
 The v-on:listeners is rquired, v-on:attrs may or may not be required depending on your implementation.
 :::

--- a/packages/gmap-vue/src/components-implementation/autocomplete.js
+++ b/packages/gmap-vue/src/components-implementation/autocomplete.js
@@ -26,7 +26,13 @@ const props = {
     type: Boolean,
     default: false,
   },
-  // the name of the ref to obtain the input (if its a child  of component in the slot)
+  // the unique ref of the slot component
+  slotRefName: {
+    required: false,
+    type: String,
+    default: 'input'
+  },
+  // the name of the ref to obtain the input (if its a child of component in the slot)
   childRefName: {
     required: false,
     type: String,
@@ -47,7 +53,7 @@ export default {
     this.$gmapApiPromiseLazy().then(() => {
       let scopedInput = null;
       if (this.$scopedSlots.input) {
-        scopedInput = this.$scopedSlots.input()[0].context.$refs.input;
+        scopedInput = this.$scopedSlots.input()[0].context.$refs[this.slotRefName];
         if (scopedInput && scopedInput.$refs) {
           scopedInput = scopedInput.$refs[this.childRefName || 'input'];
         }


### PR DESCRIPTION
This issue had me pulling my hair for an hour. After checking my code for the hundredth time, I decided to look into the code of this package to see if the issue was there.

### The Issue
**This only occurs when you create a `gmap-autocomplete` component with another component in its slot.**

If you create only one `gmap-autocomplete` component, it works fine but if there's more than one; only the last one will work.  Not only that, if you have another component or element somewhere in the context with the `ref` "input", it will ignore the slot and apply autocomplete to that.

### What's causing it
At line 50, there's `this.$scopedSlots.input()[0].context.$refs.input`. As it's accessing the context of the slotted component (which is the context of its parent component), `$refs.input` can refer to anything in that context with the same ref. Here's an example:

Here only the second component will work:

```
<gmap-autocomplete>
  <template ...>
    <my-component ref="input" />
   </template>
</gmap-autocomplete>

<gmap-autocomplete>
  <template ...>
    <my-component ref="input" />
   </template>
</gmap-autocomplete>
````

And here the `<input />` outside `gmap-autocomplete` will get autocomplete:

```
<gmap-autocomplete>
  <template ...>
    <my-component ref="input" />
   </template>
</gmap-autocomplete>

<input ref="input" />
````

### The Fix
I have added a new prop `slotRefName` which can be used to specify the unique ref of the slot if there's more than one instance of `gmap-autocomplete` or to avoid conflict with other elements. 

You can now do this if you have multiple instances:

```
<gmap-autocomplete slot-ref-name="address1">
  <template ...>
    <my-component ref="address1" />
   </template>
</gmap-autocomplete>

<gmap-autocomplete slot-ref-name="address2">
  <template ...>
    <my-component ref="address2" />
   </template>
</gmap-autocomplete>
```