### PR TITLE
fix(documentation): update code sample for gmapmarker

### DIFF
--- a/packages/documentation/docs/README.md
+++ b/packages/documentation/docs/README.md
@@ -72,8 +72,8 @@ If you are using Webpack and Vue file components, just add the following to your
     :key="index"
     v-for="(m, index) in markers"
     :position="m.position"
-    :clickable="true"
-    :draggable="true"
+    :clickable=true
+    :draggable=true
     @click="center=m.position"
   />
 </GmapMap>


### PR DESCRIPTION
Hello gmap-vue team,

Thank you for maintaining this!

I stumbled around trying to figure out why my marker was unclickable, only to find out the `clickable` property in the docs is `string`, whereas the [source code](https://github.com/diegoazh/gmap-vue/blob/master/packages/gmap-vue/src/components/marker.js#L12) shows it should be type `boolean`. Same with the property `draggable`, the docs show its a string, whereas the [source code](https://github.com/diegoazh/gmap-vue/blob/master/packages/gmap-vue/src/components/marker.js#L21) shows it should be type `boolean`. I'm hoping this helps someone in the future.

Thanks again.