### PR TITLE
Wrong Function call

### DIFF
--- a/packages/documentation/docs/guide/cdn.md
+++ b/packages/documentation/docs/guide/cdn.md
@@ -31,7 +31,7 @@ If you want to use a CDN it is available on unpkg and jsdelivr, the above is an 
 
     document.addEventListener('DOMContentLoaded', function() {
       Vue.component('google-map', GmapVue.Map);
-      Vue.component('ground-overlay', GmapVue.mapElementFactory({
+      Vue.component('ground-overlay', GmapVue.MapElementFactory({
         mappedProps: {
           'opacity': {}
         },


### PR DESCRIPTION
Capitalize the first letter "m"  in mapElementFactory to get access to the MapElementFactory function .