### PR TITLE
bind dragend to shape in drawing manager

### DIFF
--- a/packages/gmap-vue/src/components/drawing-manager.vue
+++ b/packages/gmap-vue/src/components/drawing-manager.vue
@@ -297,6 +297,9 @@ export default {
       google.maps.event.addListener(shape.overlay, 'rightclick', () => {
         self.deleteSelection();
       });
+      google.maps.event.addListener(shape.overlay, 'dragend', () => {
+         this.$emit('update:shapes', [...this.finalShapes]);
+      });
       this.setSelection(shape);
     },
   },


### PR DESCRIPTION
This would resolve an issue with the drawing manager not binding the drag update properly. Now the 'dragend' event will be added when the shape created