### PR TITLE
fix(v3): change inject for composable to get component promise 

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 20
       - name: Install pnpm
-        run: npm install --location=global pnpm
+        run: npm install --location=global pnpm@9.0.6
       - name: Remove pnpm-workspace.yaml
         run: rm -rf ./pnpm-workspace.yaml
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@9.0.6
       - name: Install dependencies
         run: pnpm install
       - name: Create env file

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:diegoazh/gmap-vue.git",
   "author": "\"Daniel Sim, Guillaume Leclerc\",",
   "license": "MIT",
-  "packageManager": "pnpm@9.0.5",
+  "packageManager": "pnpm@9.0.6",
   "scripts": {
     "serve:docs": "pnpm run --filter docs start",
     "build:all": "pnpm run --recursive build",

--- a/packages/v3/cypress/runner/components/ClusterTest.vue
+++ b/packages/v3/cypress/runner/components/ClusterTest.vue
@@ -6,13 +6,15 @@
       style="width: 100%; height: 500px"
       mapId="DEMO_MAP_ID"
     >
-      <gmv-cluster>
+      <gmv-cluster clusterKey="myCluster">
         <gmv-marker
           v-for="(m, index) in markers"
           :key="index"
           :clickable="true"
           :draggable="true"
           :position="m.position"
+          :marker-key="`marker-${index}`"
+          clusterKey="myCluster"
           @click="center = m.position"
         ></gmv-marker>
       </gmv-cluster>


### PR DESCRIPTION
The inject key can only be used on descendants, not on siblings. It's more accurate to use composables on the mounted hook.

Solve: #323 