### PR TITLE
fix(v3): update 'useTemplateRef' key

### DIFF
--- a/packages/v3/src/components/autocomplete-input.vue
+++ b/packages/v3/src/components/autocomplete-input.vue
@@ -6,7 +6,7 @@
         - `attrs`, it's type is `object`, it's all attributes passed to the component ([vm.$attrs](https://vuejs.org/v2/api/?#vm-attrs))<br>
 			-->
     <slot :attrs="$attrs">
-      <input ref="gmvAutoCompleteInput" v-bind="$attrs" />
+      <input ref="gmvAutoCompleteInputRef" v-bind="$attrs" />
     </slot>
   </div>
 </template>
@@ -86,7 +86,7 @@ const props = withDefaults(
  * TEMPLATE REF, ATTRIBUTES, EMITTERS AND SLOTS
  ******************************************************************************/
 const gmvAutoCompleteInput = useTemplateRef<HTMLInputElement | null>(
-  'gmvAutoCompleteInput',
+  'gmvAutoCompleteInputRef',
 );
 const emits = defineEmits<{
   place_changed: [value: google.maps.places.PlaceResult];

--- a/packages/v3/src/components/info-window.vue
+++ b/packages/v3/src/components/info-window.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="info-window-container">
-    <div ref="gmvInfoWindow" class="info-window-content">
+    <div ref="gmvInfoWindowRef" class="info-window-content">
       <!-- so named because it will fly away to another component -->
       <!-- @slot Used to set your info window.  -->
       <slot />
@@ -82,7 +82,7 @@ const props = withDefaults(
 /*******************************************************************************
  * TEMPLATE REF, ATTRIBUTES, EMITTERS AND SLOTS
  ******************************************************************************/
-const gmvInfoWindow = useTemplateRef<HTMLElement | null>('gmvInfoWindow');
+const gmvInfoWindow = useTemplateRef<HTMLElement | null>('gmvInfoWindowRef');
 const emits = defineEmits<{
   close: [];
   closeclick: [];

--- a/packages/v3/src/components/map-layer.vue
+++ b/packages/v3/src/components/map-layer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="gmv-map-container">
-    <div ref="gmvMap" class="gmv-map" />
+    <div ref="gmvMapRef" class="gmv-map" />
     <div class="gmv-map-hidden">
       <!-- @slot The default slot is wrapped in a class that sets display: none; so by default any component you add to your map will be invisible. This is ok for most of the supplied components that interact directly with the Google map object, but it's not good if you want to bring up things like toolboxes, etc. -->
       <slot />
@@ -139,7 +139,7 @@ const props = withDefaults(
 /*******************************************************************************
  * TEMPLATE REF, ATTRIBUTES AND EMITTERS
  ******************************************************************************/
-const gmvMap = useTemplateRef<HTMLElement | null>('gmvMap');
+const gmvMap = useTemplateRef<HTMLElement | null>('gmvMapRef');
 const emits = defineEmits<{
   bounds_changed: [value: google.maps.LatLngBounds | undefined];
   center_changed: [value: google.maps.LatLng | undefined];

--- a/packages/v3/src/components/street-view-panorama.vue
+++ b/packages/v3/src/components/street-view-panorama.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="gmv-street-view-panorama-container">
-    <div ref="gmvStreetViewPanorama" class="gmv-street-view-panorama" />
+    <div ref="gmvStreetViewPanoramaRef" class="gmv-street-view-panorama" />
     <!-- @slot A default slot to render the street view panorama -->
     <slot></slot>
   </div>
@@ -100,7 +100,7 @@ const props = withDefaults(
  * TEMPLATE REF, ATTRIBUTES, EMITTERS AND SLOTS
  ******************************************************************************/
 const gmvStreetViewPanorama = useTemplateRef<HTMLDivElement | null>(
-  'gmvStreetViewPanorama',
+  'gmvStreetViewPanoramaRef',
 );
 const emits = defineEmits<{
   closeclick: [value: Event];


### PR DESCRIPTION
## Issue Description:

**vue version:** `3.5.15`
**gmap-vue version:** `2.1.3`

I ran into a problem when using the plugin:`[Vue warn] Set operation on key "value" failed: target is readonly.`, this warn message should only appear before vue(version: 3.5.2) [Related fixes](https://github.com/vuejs/core/issues/11795), According to the correction of #340, the `useTemplateRef` syntax is used in version 2.1.3, I tried to find out where the problem is and found that some edge cases will cause the problem to occur when the key of useTemplateRef is the same as the variable name. However, according to my own codebase, this problem does not occur, but when the plugin is referenced, the plugin This writing method causes the warning.