### PR TITLE
refactor(v3): harden runtime loader state

### DIFF
--- a/openspec/changes/vue3-next-level-modernization/apply-progress.md
+++ b/openspec/changes/vue3-next-level-modernization/apply-progress.md
@@ -1,0 +1,65 @@
+# Apply Progress: vue3-next-level-modernization
+
+## Phase 2 — Runtime Quality Hardening
+
+Status: complete
+Mode: Strict TDD
+
+### RED evidence
+
+Added `packages/v3/tests/runtime-hardening.spec.ts` before implementation. The first run produced the intended runtime-hardening failures:
+
+```text
+$ cd packages/v3 && pnpm run test:ci -- tests/runtime-hardening.spec.ts
+FAIL tests/runtime-hardening.spec.ts > imports the main entry without creating or overwriting GoogleMapsApi global state
+  expected { isReady: false } to be { isReady: true }
+FAIL tests/runtime-hardening.spec.ts > keeps deprecated module-level plugin options compatible with the latest install
+  expected key "first" to equal key "second"
+FAIL tests/runtime-hardening.spec.ts > settles the lazy Google Maps API promise safely when window is unavailable
+  Test timed out in 5000ms
+```
+
+The same command also surfaced pre-existing package-surface failures because `dist/` was not built in the fresh worktree; those were resolved by running the build before the full suite.
+
+### GREEN / refactor summary
+
+- Removed import-time `globalThis.GoogleMapsApi = { isReady: false }` mutation from `packages/v3/src/main.ts`.
+- Added install-time typed runtime state for each plugin install and kept `utilities.getGoogleMapsAPI` functional through controlled module state instead of import-time global mutation.
+- Changed the promise lazy builder to use the provided per-install API state, settle safely with `undefined` when `window` is unavailable, and avoid invoking the Google Maps initializer in SSR/no-window mode.
+- Changed deprecated module-level `saveLazyPromiseAndFinalOptions` compatibility behavior from first-write-wins to latest-install fallback so it no longer leaks the first app forever.
+- Added timer cleanup around the Google Maps callback polling loop.
+- Tightened targeted public typings for lazy values and `IGmapVueElementOptions` constructor arguments without changing public API names.
+
+### Review blocker follow-up
+
+A fresh review found that the first GREEN pass still let components read latest module-level fallback state, concurrent lazy builders could race through a shared callback, and `utilities.getGoogleMapsAPI` only tracked the latest install state. The follow-up fix:
+
+- Added `$gmapApiPromiseLazy` injection key and provided app-scoped lazy/options from plugin install.
+- Updated deprecated composables to prefer injected app context when called from components/lifecycle hooks, while preserving module-level latest-install fallback outside app context.
+- Replaced per-lazy global callback overwrite with a dispatcher over pending ready callbacks; polling now resolves each lazy instance through its own callback and cleans its own timers.
+- Changed `utilities.getGoogleMapsAPI` to inspect all installed runtime states plus legacy/global readiness instead of only the latest state.
+- Updated aggregate composable typing so `useGoogleMapsApiPromiseLazy` can return `undefined` when the lazy fallback has not been created.
+
+### Verification
+
+```text
+$ cd packages/v3 && pnpm exec vitest run tests/main.spec.ts tests/promise-lazy-builder.spec.ts tests/google-maps-api-initializer.spec.ts tests/runtime-hardening.spec.ts
+4 files passed, 21 tests passed
+
+$ cd packages/v3 && pnpm run test:ci
+23 files passed, 105 tests passed
+
+$ cd packages/v3 && pnpm run type-check
+passed
+
+$ cd packages/v3 && pnpm run build
+passed
+
+$ cd packages/v3 && pnpm exec eslint src/main.ts src/composables/promise-lazy-builder.ts src/interfaces/gmap-vue.interface.ts src/types/gmap-vue.type.ts src/keys/gmap-vue.keys.ts tests/main.spec.ts tests/promise-lazy-builder.spec.ts tests/runtime-hardening.spec.ts
+passed
+```
+
+### Notes / risks
+
+- Script injection remains a global loader singleton by design; app options/lazy runtime state are scoped per install with a latest-install deprecated fallback.
+- Root `pnpm run lint`, root `pnpm run test`, and root `pnpm run test:e2e` were not run in this worker; e2e may require `packages/v3/cypress/runner/.env` with a Google API key.

--- a/openspec/changes/vue3-next-level-modernization/tasks.md
+++ b/openspec/changes/vue3-next-level-modernization/tasks.md
@@ -24,6 +24,7 @@ Chain strategy: pending
 | 2 | Harden loader/global lifecycle safety | PR 2 | Base PR 1 or main; SSR/no-window + multi-app isolation |
 | 3 | Relaunch Vue 3 docs as primary | PR 3 | Base PR 2 or main; Vue 2 legacy messaging kept reachable |
 | 4 | Add/align CI quality gates | PR 4 | Base PR 3 or main; workflow checks only |
+| 5 | Harden npm supply-chain posture | PR 5 | Final careful slice; apply `lirantal/npm-security-best-practices` selectively for pnpm 10 |
 
 ## Phase 1: Package Surface Contract (TDD-first)
 
@@ -34,11 +35,11 @@ Chain strategy: pending
 
 ## Phase 2: Runtime Quality Hardening (TDD-first)
 
-- [ ] 2.1 RED: Add failing tests for SSR/no-window safety and no `window`/`document` requirement on import/install paths.
-- [ ] 2.2 RED: Add failing tests for multi-app isolation and cross-app global leakage.
-- [ ] 2.3 GREEN: Implement typed loader/state boundary in `packages/v3/src/main.ts` and relevant composables without changing public API names.
-- [ ] 2.4 GREEN: Add lifecycle cleanup behavior and keep deprecated behavior functional within policy.
-- [ ] 2.5 REFACTOR: Tighten targeted public typings in `packages/v3/src/interfaces/*` and `packages/v3/src/types/*`.
+- [x] 2.1 RED: Add failing tests for SSR/no-window safety and no `window`/`document` requirement on import/install paths.
+- [x] 2.2 RED: Add failing tests for multi-app isolation and cross-app global leakage.
+- [x] 2.3 GREEN: Implement typed loader/state boundary in `packages/v3/src/main.ts` and relevant composables without changing public API names.
+- [x] 2.4 GREEN: Add lifecycle cleanup behavior and keep deprecated behavior functional within policy.
+- [x] 2.5 REFACTOR: Tighten targeted public typings in `packages/v3/src/interfaces/*` and `packages/v3/src/types/*`.
 
 ## Phase 3: Vue 3 Docs Relaunch
 
@@ -51,3 +52,13 @@ Chain strategy: pending
 - [ ] 4.1 Add/adjust `.github/workflows/*` gates for v3 build, `test:ci`, type-check, and package smoke-test checks.
 - [ ] 4.2 Add/adjust docs workflow gates for `pnpm run --filter docs build` and `pnpm run --filter docs typecheck`.
 - [ ] 4.3 Define pre-apply verification checklist in change notes (root lint/test/e2e deferred until user confirmation).
+
+## Phase 5: npm Supply-Chain Security Hardening (careful final slice)
+
+Reference: https://github.com/lirantal/npm-security-best-practices
+
+- [ ] 5.1 RED/DISCOVERY: Audit current pnpm install/build-script behavior and identify dependencies that require lifecycle scripts.
+- [ ] 5.2 GREEN: Add compatible pnpm 10 supply-chain settings to `pnpm-workspace.yaml`, including publish cooldown and exotic/git subdependency blocking where safe.
+- [ ] 5.3 GREEN: Define explicit build-script allowlist with `allowBuilds` and enable `strictDepBuilds` only after required exceptions are known.
+- [ ] 5.4 GREEN: Document security rationale, exceptions, and local/CI install workflow impact.
+- [ ] 5.5 VERIFY: Run install/lockfile validation and CI-equivalent package checks to prove the hardening does not break contributors or releases.

--- a/packages/v3/src/composables/promise-lazy-builder.ts
+++ b/packages/v3/src/composables/promise-lazy-builder.ts
@@ -1,16 +1,30 @@
 import type { IGmapVuePluginOptions, IGoogleMapsApiObject } from '@/interfaces';
+import { $gmapApiPromiseLazy, $gmapOptions } from '@/keys';
 import type {
   TGlobalGoogleObject,
   TGoogleMapsAPIInitializerFn,
   TLazyValueGetterFn,
   TPromiseLazyCreatorFn,
 } from '@/types';
+import { getCurrentInstance, inject } from 'vue';
 import { getLazyValue } from './helpers';
 
 let $finalOptions: IGmapVuePluginOptions | undefined;
 let $googleMapsApiPromiseLazy:
-  | TLazyValueGetterFn<TGlobalGoogleObject>
+  | TLazyValueGetterFn<TGlobalGoogleObject | undefined>
   | undefined;
+
+const googleMapsReadyCallbacks = new Set<() => void>();
+
+function dispatchGoogleMapsReadyCallbacks(): void {
+  for (const callback of Array.from(googleMapsReadyCallbacks)) {
+    callback();
+  }
+}
+
+function ensureGlobalGoogleMapsCallback(): void {
+  globalThis.GoogleMapsCallback = dispatchGoogleMapsReadyCallbacks;
+}
 
 /**
  * This function is a factory of the promise lazy creator
@@ -29,20 +43,26 @@ export function usePromiseLazyBuilderFn(
 ): TPromiseLazyCreatorFn {
   return (
     options: IGmapVuePluginOptions,
-  ): TLazyValueGetterFn<TGlobalGoogleObject> => {
+  ): TLazyValueGetterFn<TGlobalGoogleObject | undefined> => {
     /**
      * Things to do once the API is loaded
      *
      * @returns {Object} the Google Maps API object
      */
-    function onMapsReady(): TGlobalGoogleObject {
+    function onMapsReady(): TGlobalGoogleObject | undefined {
       GoogleMapsApi.isReady = true;
       return globalThis.google;
     }
 
-    return getLazyValue(() =>
-      createFinalPromise(options, googleMapsApiInitializer, onMapsReady),
-    );
+    return getLazyValue(() => {
+      if (typeof window === 'undefined') {
+        return Promise.resolve(undefined);
+      }
+
+      return createFinalPromise(options, googleMapsApiInitializer).then(
+        onMapsReady,
+      );
+    });
   };
 }
 
@@ -54,36 +74,48 @@ export function usePromiseLazyBuilderFn(
  *
  * @internal
  */
-function createCallbackAndChecksIfMapIsLoaded(
-  resolveFn: (value?: unknown) => void,
-): void {
+function createCallbackAndChecksIfMapIsLoaded(resolveFn: () => void): void {
   let callbackExecuted = false;
+  let timeoutId: number | undefined;
+  let intervalId: number | undefined;
 
-  globalThis.GoogleMapsCallback = (): void => {
+  function cleanupTimers(): void {
+    if (timeoutId !== undefined) {
+      globalThis.clearTimeout(timeoutId);
+      timeoutId = undefined;
+    }
+
+    if (intervalId !== undefined) {
+      globalThis.clearInterval(intervalId);
+      intervalId = undefined;
+    }
+  }
+
+  function resolveCurrentCallback(): void {
+    if (callbackExecuted) {
+      return;
+    }
+
     try {
       resolveFn();
     } catch (error) {
       globalThis.console.error('Error executing the GoogleMapsCallback', error);
     } finally {
       callbackExecuted = true;
+      cleanupTimers();
+      googleMapsReadyCallbacks.delete(resolveCurrentCallback);
     }
-  };
+  }
 
-  let timeoutId: number | undefined = window.setTimeout(() => {
-    let intervalId: number | undefined = window.setInterval(() => {
-      if (timeoutId) {
-        globalThis.clearTimeout(timeoutId);
-        timeoutId = undefined;
-      }
+  googleMapsReadyCallbacks.add(resolveCurrentCallback);
+  ensureGlobalGoogleMapsCallback();
 
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (window.google.maps != null && !callbackExecuted) {
-        globalThis.GoogleMapsCallback();
-      }
+  timeoutId = window.setTimeout(() => {
+    const runtimeWindow = window as Window & { google?: TGlobalGoogleObject };
 
-      if (callbackExecuted) {
-        clearInterval(intervalId);
-        intervalId = undefined;
+    intervalId = window.setInterval(() => {
+      if (runtimeWindow.google?.maps != null) {
+        resolveCurrentCallback();
       }
     }, 500);
   }, 1000);
@@ -96,21 +128,13 @@ function createCallbackAndChecksIfMapIsLoaded(
  *
  * @param  {IGmapVuePluginOptions} options
  * @param  {TGoogleMapsAPIInitializerFn} googleMapsApiInitializer
- * @param  {()=>TGlobalGoogleObject} onMapsReady
- *
  * @internal
  */
 function createFinalPromise(
   options: IGmapVuePluginOptions,
   googleMapsApiInitializer: TGoogleMapsAPIInitializerFn,
-  onMapsReady: () => TGlobalGoogleObject,
-): Promise<TGlobalGoogleObject> {
+): Promise<void> {
   return new Promise((resolve, reject) => {
-    if (typeof window === 'undefined') {
-      // Do nothing if run from server-side
-      return undefined;
-    }
-
     try {
       createCallbackAndChecksIfMapIsLoaded(resolve);
 
@@ -128,7 +152,7 @@ function createFinalPromise(
         reject(error);
       }
     }
-  }).then(onMapsReady);
+  });
 }
 
 /**
@@ -144,15 +168,28 @@ function createFinalPromise(
  */
 export function saveLazyPromiseAndFinalOptions(
   finalOptions: IGmapVuePluginOptions,
-  googleMapsApiPromiseLazy: TLazyValueGetterFn<TGlobalGoogleObject>,
+  googleMapsApiPromiseLazy: TLazyValueGetterFn<TGlobalGoogleObject | undefined>,
 ): void {
-  if (!$finalOptions) {
-    $finalOptions = finalOptions;
+  $finalOptions = finalOptions;
+  $googleMapsApiPromiseLazy = googleMapsApiPromiseLazy;
+}
+
+function useInjectedGoogleMapsApiPromiseLazy():
+  | TLazyValueGetterFn<TGlobalGoogleObject | undefined>
+  | undefined {
+  if (!getCurrentInstance()) {
+    return undefined;
   }
 
-  if (!$googleMapsApiPromiseLazy) {
-    $googleMapsApiPromiseLazy = googleMapsApiPromiseLazy;
+  return inject($gmapApiPromiseLazy, undefined);
+}
+
+function useInjectedPluginOptions(): IGmapVuePluginOptions | undefined {
+  if (!getCurrentInstance()) {
+    return undefined;
   }
+
+  return inject($gmapOptions, undefined);
 }
 
 /**
@@ -166,11 +203,14 @@ export function saveLazyPromiseAndFinalOptions(
 export function useGoogleMapsApiPromiseLazy():
   | Promise<TGlobalGoogleObject | undefined>
   | undefined {
-  if (!$googleMapsApiPromiseLazy) {
+  const googleMapsApiPromiseLazy =
+    useInjectedGoogleMapsApiPromiseLazy() ?? $googleMapsApiPromiseLazy;
+
+  if (!googleMapsApiPromiseLazy) {
     globalThis.console.warn('$googleMapsApiPromiseLazy was not created yet...');
   }
 
-  return $googleMapsApiPromiseLazy?.();
+  return googleMapsApiPromiseLazy?.();
 }
 
 /**
@@ -180,9 +220,11 @@ export function useGoogleMapsApiPromiseLazy():
  * @returns IPluginOptions
  */
 export function usePluginOptions(): IGmapVuePluginOptions | undefined {
-  if (!$finalOptions) {
+  const finalOptions = useInjectedPluginOptions() ?? $finalOptions;
+
+  if (!finalOptions) {
     globalThis.console.warn('$finalOptions was not defined yet...');
   }
 
-  return $finalOptions;
+  return finalOptions;
 }

--- a/packages/v3/src/interfaces/gmap-vue.interface.ts
+++ b/packages/v3/src/interfaces/gmap-vue.interface.ts
@@ -87,18 +87,18 @@ export interface IGoogleMapProp {
   trackProperties?: string[];
 }
 
+export type TGoogleMapsConstructor = new (...args: unknown[]) => unknown;
+
 export interface IGmapVueElementOptions {
   mappedProps: Omit<ISinglePluginComponentConfig, 'events'>;
   props: Record<string, IVueProp>;
   events: string[];
   name: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ctr: () => (...args: any[]) => InstanceType<any>;
+  ctr: () => TGoogleMapsConstructor;
   ctrArgs?: (
     options: Record<string, unknown>,
     props: Record<string, IVueProp | undefined>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ) => Record<string, any>[];
+  ) => unknown[];
   beforeCreate?: (options: Record<string, unknown>) => unknown;
   afterCreate?: (mapElementInstance: Record<string, unknown>) => unknown;
 }

--- a/packages/v3/src/keys/gmap-vue.keys.ts
+++ b/packages/v3/src/keys/gmap-vue.keys.ts
@@ -1,6 +1,7 @@
 import type { MarkerClusterer } from '@googlemaps/markerclusterer';
 import type { InjectionKey } from 'vue';
 import type { IGmapVuePluginOptions } from '../interfaces';
+import type { TGlobalGoogleObject, TLazyValueGetterFn } from '../types';
 
 export const $recyclePrefix = '__gmc__';
 export const $autocompletePromise = Symbol(
@@ -44,4 +45,7 @@ export const $drawingManagerPromise = Symbol(
 ) as InjectionKey<Promise<google.maps.drawing.DrawingManager | undefined>>;
 export const $gmapOptions = Symbol('gmapOptions') as InjectionKey<
   IGmapVuePluginOptions | undefined
+>;
+export const $gmapApiPromiseLazy = Symbol('gmapApiPromiseLazy') as InjectionKey<
+  TLazyValueGetterFn<TGlobalGoogleObject | undefined>
 >;

--- a/packages/v3/src/main.ts
+++ b/packages/v3/src/main.ts
@@ -19,10 +19,14 @@ import {
   usePromiseLazyBuilderFn,
 } from '@/composables';
 import type { IGmapVuePluginOptions, IGoogleMapsApiObject } from '@/interfaces';
-import type { TGlobalGoogleObject, IGmvUtilities } from '@/types';
+import type {
+  TGlobalGoogleObject,
+  IGmvUtilities,
+  TLazyValueGetterFn,
+} from '@/types';
 import type { Emitter, EventType } from 'mitt';
 import { defineAsyncComponent, type App, type FunctionPlugin } from 'vue';
-import { $gmapOptions } from './keys';
+import { $gmapApiPromiseLazy, $gmapOptions } from './keys';
 
 /**
  * Vue augmentations
@@ -30,7 +34,7 @@ import { $gmapOptions } from './keys';
 declare module 'vue' {
   interface ComponentCustomProperties {
     $gmapDefaultResizeBus: Emitter<Record<EventType, unknown>>;
-    $gmapApiPromiseLazy: () => Promise<unknown>;
+    $gmapApiPromiseLazy: TLazyValueGetterFn<TGlobalGoogleObject | undefined>;
     $gmapOptions: IGmapVuePluginOptions;
   }
   interface GlobalComponents {
@@ -51,12 +55,12 @@ declare module 'vue' {
 
 declare global {
   // eslint-disable-next-line no-var
-  var GoogleMapsApi: IGoogleMapsApiObject;
+  var GoogleMapsApi: IGoogleMapsApiObject | undefined;
   // eslint-disable-next-line no-var
   var GoogleMapsCallback: () => void;
 
   interface Window {
-    GoogleMapsApi: IGoogleMapsApiObject;
+    GoogleMapsApi?: IGoogleMapsApiObject;
     GoogleMapsCallback: () => unknown;
     google?: TGlobalGoogleObject;
 
@@ -65,20 +69,42 @@ declare global {
 }
 
 /**
- * @var
- * @type {Object|undefined}
- *
- * An independent Vue instance that helps us to know when the Google Maps API is loaded.
- */
-globalThis.GoogleMapsApi = { isReady: false };
-
-/**
  * This function helps you to get the Google Maps API
- * when its ready on the window object
+ * when its ready on the window object.
+ *
+ * Runtime state is intentionally created during plugin install instead of module
+ * import so SSR imports do not mutate global objects.
  * @function
  */
+const installedGoogleMapsApiStates = new Set<IGoogleMapsApiObject>();
+
 function getGoogleMapsAPI(): false | TGlobalGoogleObject {
-  return globalThis.GoogleMapsApi.isReady && globalThis.google;
+  const googleObject = (globalThis as Record<string, unknown>).google;
+
+  if (typeof googleObject !== 'object' || googleObject === null) {
+    return false;
+  }
+
+  const runtimeStateIsReady = Array.from(installedGoogleMapsApiStates).some(
+    (state) => state.isReady,
+  );
+  const legacyStateIsReady =
+    (globalThis as { GoogleMapsApi?: IGoogleMapsApiObject }).GoogleMapsApi
+      ?.isReady === true;
+  const globalMapsIsReady = 'maps' in googleObject;
+
+  if (!runtimeStateIsReady && !legacyStateIsReady && !globalMapsIsReady) {
+    return false;
+  }
+
+  return googleObject as TGlobalGoogleObject;
+}
+
+function createGoogleMapsApiState(): IGoogleMapsApiObject {
+  const googleMapsApiState = { isReady: false };
+  installedGoogleMapsApiStates.add(googleMapsApiState);
+
+  return googleMapsApiState;
 }
 
 /**
@@ -127,9 +153,10 @@ const createGmapVuePlugin = (
      * @constant
      * @type {Function} the promise lazy creator function
      */
+    const googleMapsApiState = createGoogleMapsApiState();
     const promiseLazyCreator = usePromiseLazyBuilderFn(
       googleMapsApiInitializer,
-      globalThis.GoogleMapsApi,
+      googleMapsApiState,
     );
     /**
      * The googleMapsApiPromiseLazy function to can wait until Google Maps API is ready
@@ -150,6 +177,7 @@ const createGmapVuePlugin = (
      */
     app.config.globalProperties.$gmapApiPromiseLazy = googleMapsApiPromiseLazy;
     app.config.globalProperties.$gmapOptions = finalOptions;
+    app.provide($gmapApiPromiseLazy, googleMapsApiPromiseLazy);
     app.provide($gmapOptions, finalOptions);
 
     app

--- a/packages/v3/src/types/gmap-vue.type.ts
+++ b/packages/v3/src/types/gmap-vue.type.ts
@@ -87,7 +87,7 @@ export type TLazyValueGetterFn<T> = () => Promise<T>;
 /** @internal */
 export type TPromiseLazyCreatorFn = (
   options: IGmapVuePluginOptions,
-) => TLazyValueGetterFn<TGlobalGoogleObject>;
+) => TLazyValueGetterFn<TGlobalGoogleObject | undefined>;
 
 /** @internal */
 export type TOldHtmlInputElement = HTMLInputElement & {
@@ -120,11 +120,13 @@ export interface IGmvSharedComposables {
     _resizeCallback: () => void;
     _delayedResizeCallback: () => Promise<void>;
   };
-  useGoogleMapsApiPromiseLazy: () => Promise<unknown>;
+  useGoogleMapsApiPromiseLazy: () =>
+    | Promise<TGlobalGoogleObject | undefined>
+    | undefined;
   useStreetViewPanoramaPromise: () => Promise<
     google.maps.StreetViewPanorama | undefined
   >;
-  usePluginOptions: () => IGmapVuePluginOptions;
+  usePluginOptions: () => IGmapVuePluginOptions | undefined;
 }
 
 export interface IGmvUtilities {

--- a/packages/v3/tests/main.spec.ts
+++ b/packages/v3/tests/main.spec.ts
@@ -1,8 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { IGmapVuePluginOptions } from '../src/interfaces';
 import * as main from '../src/main';
 
+const globalRecord = globalThis as Record<string, unknown>;
+
 describe('main.ts module', () => {
+  beforeEach(() => {
+    delete globalRecord.GoogleMapsApi;
+  });
+
+  afterEach(() => {
+    delete globalRecord.GoogleMapsApi;
+  });
+
   it('should export one function and one object with three functions', () => {
     // arrange
     const options: IGmapVuePluginOptions = {
@@ -25,10 +35,6 @@ describe('main.ts module', () => {
     expect(main.utilities.pluginComponentBuilder).toBeTypeOf('function');
     expect(main.utilities.getGoogleMapsAPI).toBeTypeOf('function');
     expect(installFn).toBeTypeOf('function');
-    expect(globalThis.GoogleMapsApi).toBeDefined();
-    expect(globalThis.GoogleMapsApi).toBeTypeOf('object');
-    expect(Object.keys(globalThis.GoogleMapsApi)).toHaveLength(1);
-    expect(Object.keys(globalThis.GoogleMapsApi)).toEqual(['isReady']);
-    expect(globalThis.GoogleMapsApi.isReady).toBeFalsy();
+    expect(globalRecord.GoogleMapsApi).toBeUndefined();
   });
 });

--- a/packages/v3/tests/promise-lazy-builder.spec.ts
+++ b/packages/v3/tests/promise-lazy-builder.spec.ts
@@ -4,12 +4,14 @@ import type { TGlobalGoogleObject } from '../src/types/gmap-vue.type';
 
 describe('promise-lazy-builder', () => {
   let promiseLazyBuilder: {
-    usePluginOptions: () => IGmapVuePluginOptions;
+    usePluginOptions: () => IGmapVuePluginOptions | undefined;
     saveLazyPromiseAndFinalOptions: (
-      o: Record<string, unknown>,
-      f: () => void,
+      o: IGmapVuePluginOptions,
+      f: () => Promise<TGlobalGoogleObject | undefined>,
     ) => void;
-    useGoogleMapsApiPromiseLazy: () => Promise<TGlobalGoogleObject | undefined>;
+    useGoogleMapsApiPromiseLazy: () =>
+      | Promise<TGlobalGoogleObject | undefined>
+      | undefined;
   };
 
   beforeEach(async () => {
@@ -36,9 +38,8 @@ describe('promise-lazy-builder', () => {
   test('should return the options passed to the plugin when it is initialized', () => {
     // Arrange
     const optionsMock = { load: { key: 'abc' } };
-    promiseLazyBuilder.saveLazyPromiseAndFinalOptions(
-      optionsMock,
-      () => undefined,
+    promiseLazyBuilder.saveLazyPromiseAndFinalOptions(optionsMock, () =>
+      Promise.resolve(undefined),
     );
 
     // Act
@@ -51,28 +52,31 @@ describe('promise-lazy-builder', () => {
   test('should save the options and the API promise lazy when its called', () => {
     // Arrange
     const optionsMock = { load: { key: 'abc' } };
-    const fnMock = () => 'this is a test';
+    const promiseMock = Promise.resolve({ version: 'test' });
+    const fnMock = () => promiseMock;
 
     // Act
     promiseLazyBuilder.saveLazyPromiseAndFinalOptions(optionsMock, fnMock);
 
     expect(promiseLazyBuilder.usePluginOptions()).toEqual(optionsMock);
-    expect(promiseLazyBuilder.useGoogleMapsApiPromiseLazy()).toEqual(fnMock());
+    expect(promiseLazyBuilder.useGoogleMapsApiPromiseLazy()).toBe(promiseMock);
   });
 
-  test('should only save once the options and the API promise lazy when its called', () => {
+  test('should use the latest options and API promise lazy when called more than once', () => {
     // Arrange
     const optionsMock = { load: { key: 'abc' } };
-    const fnMock = () => 'this is a test';
+    const promiseMock = Promise.resolve({ version: 'test' });
+    const fnMock = () => promiseMock;
     const optionsMock2 = { load: { key: 'def' } };
-    const fnMock2 = () => 'this is a test 2';
+    const promiseMock2 = Promise.resolve({ version: 'test 2' });
+    const fnMock2 = () => promiseMock2;
 
     // Act
     promiseLazyBuilder.saveLazyPromiseAndFinalOptions(optionsMock2, fnMock2);
     promiseLazyBuilder.saveLazyPromiseAndFinalOptions(optionsMock, fnMock);
 
-    expect(promiseLazyBuilder.usePluginOptions()).toEqual(optionsMock2);
-    expect(promiseLazyBuilder.useGoogleMapsApiPromiseLazy()).toEqual(fnMock2());
+    expect(promiseLazyBuilder.usePluginOptions()).toEqual(optionsMock);
+    expect(promiseLazyBuilder.useGoogleMapsApiPromiseLazy()).toBe(promiseMock);
   });
 
   test('should print a message when gmapApiPromiseLazy is not define', async () => {

--- a/packages/v3/tests/runtime-hardening.spec.ts
+++ b/packages/v3/tests/runtime-hardening.spec.ts
@@ -1,0 +1,240 @@
+/* eslint-disable vue/one-component-per-file */
+import {
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  onMounted,
+  type App,
+} from 'vue';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { IGmapVuePluginOptions } from '../src/interfaces';
+import type { TGlobalGoogleObject } from '../src/types';
+
+const globalRecord = globalThis as Record<string, unknown>;
+
+describe('runtime hardening', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    delete globalRecord.GoogleMapsApi;
+    delete globalRecord.GoogleMapsCallback;
+    delete globalRecord.google;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete globalRecord.GoogleMapsApi;
+    delete globalRecord.GoogleMapsCallback;
+    delete globalRecord.google;
+  });
+
+  test('imports the main entry without creating or overwriting GoogleMapsApi global state', async () => {
+    const existingState = { isReady: true };
+    globalRecord.GoogleMapsApi = existingState;
+
+    await import('../src/main');
+
+    expect(globalRecord.GoogleMapsApi).toBe(existingState);
+  });
+
+  test('installs the plugin without requiring window or document', async () => {
+    vi.stubGlobal('window', undefined);
+    vi.stubGlobal('document', undefined);
+    const { createGmapVuePlugin } = await import('../src/main');
+    const app = createApp({});
+
+    expect(() => {
+      app.use(createGmapVuePlugin({ load: { key: 'abc' } }));
+    }).not.toThrow();
+
+    expect(app.config.globalProperties.$gmapOptions).toEqual({
+      dynamicLoad: false,
+      load: { libraries: 'places', key: 'abc' },
+    });
+    expect(app.config.globalProperties.$gmapApiPromiseLazy).toBeTypeOf(
+      'function',
+    );
+  });
+
+  test('keeps installed Vue app options and lazy references isolated', async () => {
+    const { createGmapVuePlugin } = await import('../src/main');
+    const firstApp = createApp({});
+    const secondApp = createApp({});
+
+    firstApp.use(createGmapVuePlugin({ load: { key: 'first' } }));
+    secondApp.use(createGmapVuePlugin({ load: { key: 'second' } }));
+
+    expect(firstApp.config.globalProperties.$gmapOptions).toEqual({
+      dynamicLoad: false,
+      load: { libraries: 'places', key: 'first' },
+    });
+    expect(secondApp.config.globalProperties.$gmapOptions).toEqual({
+      dynamicLoad: false,
+      load: { libraries: 'places', key: 'second' },
+    });
+    expect(firstApp.config.globalProperties.$gmapApiPromiseLazy).not.toBe(
+      secondApp.config.globalProperties.$gmapApiPromiseLazy,
+    );
+  });
+
+  test('keeps component composable reads scoped to the app that owns the component', async () => {
+    const { createGmapVuePlugin } = await import('../src/main');
+    const { usePluginOptions } = await import(
+      '../src/composables/promise-lazy-builder'
+    );
+    let firstAppOptions: IGmapVuePluginOptions | undefined;
+    let firstApp: App<Element> | undefined;
+
+    const ProbeComponent = defineComponent({
+      setup() {
+        onMounted(() => {
+          firstAppOptions = usePluginOptions();
+        });
+
+        return () => h('div');
+      },
+    });
+    const firstRoot = document.createElement('div');
+
+    try {
+      firstApp = createApp(ProbeComponent);
+      firstApp.use(
+        createGmapVuePlugin({ dynamicLoad: true, load: { key: 'first' } }),
+      );
+      createApp({}).use(
+        createGmapVuePlugin({ dynamicLoad: true, load: { key: 'second' } }),
+      );
+
+      firstApp.mount(firstRoot);
+      await nextTick();
+
+      expect(firstAppOptions).toEqual({
+        dynamicLoad: true,
+        load: { libraries: 'places', key: 'first' },
+      });
+    } finally {
+      firstApp?.unmount();
+    }
+  });
+
+  test('keeps deprecated module-level plugin options compatible with the latest install', async () => {
+    const { createGmapVuePlugin } = await import('../src/main');
+    const { usePluginOptions } = await import(
+      '../src/composables/promise-lazy-builder'
+    );
+    const firstApp = createApp({});
+    const secondApp = createApp({});
+
+    firstApp.use(createGmapVuePlugin({ load: { key: 'first' } }));
+    secondApp.use(createGmapVuePlugin({ load: { key: 'second' } }));
+
+    expect(usePluginOptions()).toEqual({
+      dynamicLoad: false,
+      load: { libraries: 'places', key: 'second' },
+    });
+  });
+
+  test('settles the lazy Google Maps API promise safely when window is unavailable', async () => {
+    vi.stubGlobal('window', undefined);
+    const { usePromiseLazyBuilderFn } = await import(
+      '../src/composables/promise-lazy-builder'
+    );
+    const mapsState = { isReady: false };
+    const initializer = vi.fn();
+    const lazy = usePromiseLazyBuilderFn(
+      initializer,
+      mapsState,
+    )({ load: { key: 'abc' } });
+
+    await expect(lazy()).resolves.toBeUndefined();
+    expect(mapsState.isReady).toBe(false);
+    expect(initializer).not.toHaveBeenCalled();
+  });
+
+  test('google maps initializer returns without throwing when document is unavailable', async () => {
+    vi.stubGlobal('document', undefined);
+    const { googleMapsApiInitializer } = await import(
+      '../src/composables/google-maps-api-initializer'
+    );
+
+    expect(() => {
+      googleMapsApiInitializer({ key: 'abc' });
+    }).not.toThrow();
+  });
+
+  test('clears loader polling timers after the callback resolves the API', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('google', { maps: {} } satisfies TGlobalGoogleObject);
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+    const { usePromiseLazyBuilderFn } = await import(
+      '../src/composables/promise-lazy-builder'
+    );
+    const lazy = usePromiseLazyBuilderFn(vi.fn(), { isReady: false })({
+      dynamicLoad: true,
+    });
+
+    const result = lazy();
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    await expect(result).resolves.toEqual({ maps: {} });
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+  });
+
+  test('settles concurrent lazy builders and cleans each polling interval', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('google', { maps: {} } satisfies TGlobalGoogleObject);
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+    const { usePromiseLazyBuilderFn } = await import(
+      '../src/composables/promise-lazy-builder'
+    );
+    const firstState = { isReady: false };
+    const secondState = { isReady: false };
+    const firstLazy = usePromiseLazyBuilderFn(
+      vi.fn(),
+      firstState,
+    )({
+      dynamicLoad: true,
+    });
+    const secondLazy = usePromiseLazyBuilderFn(
+      vi.fn(),
+      secondState,
+    )({
+      dynamicLoad: true,
+    });
+
+    const firstResult = firstLazy();
+    const secondResult = secondLazy();
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    await expect(Promise.all([firstResult, secondResult])).resolves.toEqual([
+      { maps: {} },
+      { maps: {} },
+    ]);
+    expect(firstState.isReady).toBe(true);
+    expect(secondState.isReady).toBe(true);
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('utilities.getGoogleMapsAPI returns google after any installed app state becomes ready', async () => {
+    vi.useFakeTimers();
+    const googleApi = { maps: {} } satisfies TGlobalGoogleObject;
+    vi.stubGlobal('google', googleApi);
+    const { createGmapVuePlugin, utilities } = await import('../src/main');
+    const firstApp = createApp({});
+    const secondApp = createApp({});
+
+    firstApp.use(createGmapVuePlugin({ dynamicLoad: true }));
+    secondApp.use(createGmapVuePlugin({ dynamicLoad: true }));
+    const firstLazy = firstApp.config.globalProperties.$gmapApiPromiseLazy;
+
+    const firstResult = firstLazy();
+    await vi.advanceTimersByTimeAsync(1_500);
+    await expect(firstResult).resolves.toBe(googleApi);
+
+    expect(utilities.getGoogleMapsAPI()).toBe(googleApi);
+  });
+});


### PR DESCRIPTION
## Summary
- harden v3 runtime initialization so SSR import/install paths avoid `window`/`document` global side effects
- scope plugin options and lazy Google Maps API state per Vue app while preserving deprecated module-level fallbacks
- make concurrent lazy loaders settle through a dispatcher and record OpenSpec Phase 2 apply progress

## Validation
- [x] `cd packages/v3 && pnpm exec vitest run tests/runtime-hardening.spec.ts tests/main.spec.ts tests/promise-lazy-builder.spec.ts tests/google-maps-api-initializer.spec.ts`
- [x] `cd packages/v3 && pnpm run test:ci` — 23 files / 105 tests passed
- [x] `cd packages/v3 && pnpm run type-check`
- [x] `cd packages/v3 && pnpm run build`
- [x] targeted non-mutating eslint/prettier checks on changed files
- [x] `pnpm run test`
- [ ] `pnpm run lint` — not run because root lint is mutating (`prettier --write` / `eslint --fix`); non-mutating targeted checks passed
- [ ] `pnpm run test:e2e` — 14/15 passed, `autocomplete-input.cy.ts` failed because Google Places suggestions did not return `.pac-item` while the map displayed "This page can't load Google Maps correctly"

## Notes
- Script injection remains intentionally global; app options/lazy state is scoped per plugin install.
- Phase 5 npm supply-chain hardening was added to the OpenSpec roadmap as a later careful slice.
