### PR TITLE
ci(v3): wire phase 4 verification gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: ci
 
 on:
   pull_request:
-    branches: "*"
+    branches:
+      - "*"
   push:
     branches:
       - master
@@ -59,8 +60,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Build package
-        working-directory: ./packages/v3
-        run: pnpm run build
+        run: pnpm run --filter @gmap-vue/v3 build
+      - name: Typecheck package
+        run: pnpm run --filter @gmap-vue/v3 type-check
       - name: Upload dist as artifact
         uses: actions/upload-artifact@v7
         with:
@@ -116,12 +118,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Create env file
+        if: matrix.test-plan == 'test:e2e'
         run: |
           touch ./packages/v3/cypress/runner/.env
           echo VITE_GOOGLE_API_KEY=${{ secrets.VITE_GOOGLE_API_KEY }} >> ./packages/v3/cypress/runner/.env
-      - name: Run unit tests
+      - name: Build package for smoke tests
         if: matrix.test-plan == 'test'
-        run: pnpm run test
+        run: pnpm run --filter @gmap-vue/v3 build
+      - name: Run unit and package smoke tests
+        if: matrix.test-plan == 'test'
+        run: pnpm run --filter @gmap-vue/v3 test:ci
       # start-server-and-test@2.0.8 → ps-tree@1.2.0 → wmic.exe, which was
       # removed from Windows Server 2025 (windows-latest). Tests complete
       # successfully but the post-test cleanup crashes with ENOENT, causing

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,20 +11,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
       - name: Use Node.js 22
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-      - name: Install pnpm
-        run: npm install --location=global pnpm@9.15.2
-      - name: Remove pnpm-workspace.yaml
-        run: rm -rf ./pnpm-workspace.yaml
+          cache: "pnpm"
       - name: Install dependencies
-        working-directory: ./packages/documentation
-        run: pnpm install
+        # Keep the root workspace visible so the temporary webpackbar override
+        # applies until Docusaurus includes the webpack 5.106+ compatibility fix.
+        run: pnpm install --frozen-lockfile
+      - name: Typecheck docs
+        run: pnpm run --filter docs typecheck
       - name: Build docs
-        working-directory: ./packages/documentation
-        run: pnpm run build
+        run: pnpm run --filter docs build
       - name: GitHub Pages
         uses: crazy-max/ghaction-github-pages@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Build package
-        working-directory: ./packages/v3
-        run: pnpm run build
-      - name: Run unit tests
-        run: pnpm run test
+        run: pnpm run --filter @gmap-vue/v3 build
+      - name: Typecheck package
+        run: pnpm run --filter @gmap-vue/v3 type-check
+      - name: Run unit and package smoke tests
+        run: pnpm run --filter @gmap-vue/v3 test:ci
       - name: Configure git credentials
         if: ${{ !inputs.dry_run }}
         uses: OleksiyRudenko/gha-git-credentials@v2.1.2

--- a/openspec/changes/vue3-next-level-modernization/apply-progress.md
+++ b/openspec/changes/vue3-next-level-modernization/apply-progress.md
@@ -101,3 +101,74 @@ A fresh review found incorrect docs examples after the first Phase 3 pass. The f
 
 - The docs build still emits known legacy warnings for deprecated `onBrokenMarkdownLinks`, existing blog author metadata, missing blog truncation markers, Vue 2 broken links/anchors, and two pre-existing developer-page `regexr.com` links.
 - The `webpackbar` override should be removed when Docusaurus is upgraded to a release that includes the webpack 5.106+ compatibility fix.
+
+## Phase 4 — CI Gates and Verification Wiring
+
+Status: complete
+Mode: workflow-only apply
+
+### Summary
+
+- Updated CI build gates to run explicit v3 package build and type-check commands with workspace filters.
+- Updated CI unit-test matrix to build `@gmap-vue/v3` in the same fresh job before running `test:ci`, so package-surface smoke tests have `packages/v3/dist` available.
+- Kept e2e matrix behavior, but limited Cypress `.env` creation to the e2e path.
+- Updated documentation publishing workflow to install dependencies from the repository root and run docs `typecheck` plus docs `build` via filters, preserving the root `webpackbar: 7.0.0` override.
+- Updated manual release workflow to build, type-check, and run v3 `test:ci` explicitly before semantic-release.
+
+### Pre-apply verification checklist
+
+Required CI-equivalent checks for this slice:
+
+```text
+pnpm install --frozen-lockfile
+pnpm run --filter @gmap-vue/v3 build
+pnpm run --filter @gmap-vue/v3 type-check
+pnpm run --filter @gmap-vue/v3 test:ci
+pnpm run --filter docs typecheck
+pnpm run --filter docs build
+```
+
+Full root validation remains available but deferred until user confirmation because e2e depends on `packages/v3/cypress/runner/.env` with `VITE_GOOGLE_API_KEY`:
+
+```text
+pnpm run lint
+pnpm run test
+pnpm run test:e2e
+```
+
+### Validation
+
+```text
+$ pnpm install --frozen-lockfile
+passed
+
+$ pnpm run --filter @gmap-vue/v3 build
+passed; emits dist/style.css for the documented stylesheet export
+
+$ pnpm run --filter @gmap-vue/v3 type-check
+passed
+
+$ pnpm run --filter @gmap-vue/v3 test:ci
+passed; 23 files, 105 tests
+
+$ pnpm run --filter docs typecheck
+passed
+
+$ pnpm run --filter docs build
+passed with known legacy Docusaurus warnings
+
+$ pnpm run lint
+passed
+
+$ pnpm run test
+passed
+
+$ pnpm run test:e2e
+passed; 11 specs, 15 tests
+```
+
+### Notes / risks
+
+- Documentation CI failed because it removed `pnpm-workspace.yaml`, bypassing the root `webpackbar: 7.0.0` override and reinstalling the incompatible Docusaurus 3.9.0 / webpackbar 6 / webpack 5.106+ combination.
+- The workflow fix intentionally keeps the root workspace visible and documents why the temporary override must remain until the Docusaurus compatibility issue is resolved upstream.
+- CI still runs e2e only in the existing matrix path; local full e2e validation should be run only with a valid Google Maps API key.

--- a/openspec/changes/vue3-next-level-modernization/tasks.md
+++ b/openspec/changes/vue3-next-level-modernization/tasks.md
@@ -49,9 +49,9 @@ Chain strategy: pending
 
 ## Phase 4: CI Gates and Verification Wiring
 
-- [ ] 4.1 Add/adjust `.github/workflows/*` gates for v3 build, `test:ci`, type-check, and package smoke-test checks.
-- [ ] 4.2 Add/adjust docs workflow gates for `pnpm run --filter docs build` and `pnpm run --filter docs typecheck`, keeping the temporary `webpackbar` override visible until Docusaurus includes the webpack 5.106+ compatibility fix.
-- [ ] 4.3 Define pre-apply verification checklist in change notes (root lint/test/e2e deferred until user confirmation).
+- [x] 4.1 Add/adjust `.github/workflows/*` gates for v3 build, `test:ci`, type-check, and package smoke-test checks.
+- [x] 4.2 Add/adjust docs workflow gates for `pnpm run --filter docs build` and `pnpm run --filter docs typecheck`, keeping the temporary `webpackbar` override visible until Docusaurus includes the webpack 5.106+ compatibility fix.
+- [x] 4.3 Define pre-apply verification checklist in change notes (root lint/test/e2e deferred until user confirmation).
 
 ## Phase 5: npm Supply-Chain Security Hardening (careful final slice)
 

--- a/packages/v3/vite.config.ts
+++ b/packages/v3/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
 
         return `${entryName}.es.js`;
       },
+      cssFileName: 'style',
       formats: ['cjs', 'es'],
     },
     rollupOptions: {


### PR DESCRIPTION
Closes #368\n\n## Summary\n- Fix documentation CI by preserving the root workspace install so the temporary webpackbar override applies.\n- Wire explicit v3 build, type-check, and test:ci/package-smoke gates in CI and release workflows.\n- Record Phase 4 OpenSpec validation evidence and force Vite to emit the documented dist/style.css artifact.\n\n## Validation\n- [x] pnpm install --frozen-lockfile\n- [x] pnpm run --filter @gmap-vue/v3 build\n- [x] pnpm run --filter @gmap-vue/v3 type-check\n- [x] pnpm run --filter @gmap-vue/v3 test:ci\n- [x] pnpm run --filter docs typecheck\n- [x] pnpm run --filter docs build\n- [x] pnpm run lint\n- [x] pnpm run test\n- [x] pnpm run test:e2e\n\n## Notes\nDocs build still reports known legacy Docusaurus/Vue 2 warnings, but exits successfully.