### PR TITLE
fix(docs): publish Docusaurus output root

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,6 +32,8 @@ jobs:
         uses: crazy-max/ghaction-github-pages@v5
         with:
           target_branch: gh-pages
-          build_dir: ./packages/documentation/build
+          # Docusaurus emits into build/gmap-vue for this GitHub Pages project.
+          # Publish that directory's contents so /gmap-vue/ has an index.html.
+          build_dir: ./packages/documentation/build/gmap-vue
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_REPO }}


### PR DESCRIPTION
## Summary

- Fix GitHub Pages publishing after Phase 4 by deploying the actual Docusaurus output directory.
- Docusaurus emits this site into `packages/documentation/build/gmap-vue`; publishing `build` created an extra nested `gmap-vue/` folder on the `gh-pages` branch and made `/gmap-vue/` return 404.

## Validation

- [x] `pnpm run --filter docs typecheck`
- [x] `pnpm run --filter docs build`
- [x] `test -f packages/documentation/build/gmap-vue/index.html`

## Notes

This is a production docs hotfix for https://diegoazh.github.io/gmap-vue/.
