### PR TITLE
fix(all): handle removed drawing library

### DIFF
--- a/packages/documentation/docs/vue-2-version/code/components/drawing-manager.mdx
+++ b/packages/documentation/docs/vue-2-version/code/components/drawing-manager.mdx
@@ -4,6 +4,10 @@ title: drawing-manager
 
   # GmapDrawingManager
 
+  :::warning Drawing Library removal
+  Google deprecated the Maps JavaScript API Drawing Library and removed `google.maps.drawing.DrawingManager` in Maps JavaScript API v3.65+. `GmapDrawingManager` is kept only for legacy API versions where Google still serves the Drawing Library. For current Maps API versions, build drawing workflows with editable shapes, the Data layer/GeoJSON, or a third-party drawing library such as Terra Draw.
+  :::
+
   
   > DrawingManager component
   

--- a/packages/documentation/docs/vue-2-version/guide/drawing-manager.md
+++ b/packages/documentation/docs/vue-2-version/guide/drawing-manager.md
@@ -2,6 +2,10 @@
 
 This component helps you to drawing shapes on over the map.
 
+:::warning Drawing Library removal
+Google deprecated the Maps JavaScript API Drawing Library and removed `google.maps.drawing.DrawingManager` in Maps JavaScript API v3.65+. `GmapDrawingManager` is kept only for legacy API versions where Google still serves the Drawing Library. For current Maps API versions, build drawing workflows with editable shapes, the Data layer/GeoJSON, or a third-party drawing library such as Terra Draw.
+:::
+
 For more information read the Google Maps documentation
 for [drawing manager](https://developers.google.com/maps/documentation/javascript/drawinglayer).
 

--- a/packages/documentation/docs/vue-3-version/api/02-gmap-vue-plugin.md
+++ b/packages/documentation/docs/vue-3-version/api/02-gmap-vue-plugin.md
@@ -35,16 +35,20 @@ export interface IGmapVuePluginOptions {
 }
 ```
 
-| Option                          | Purpose                                                                        |
-| ------------------------------- | ------------------------------------------------------------------------------ |
-| `dynamicLoad`                   | Install the plugin without immediately loading the Google Maps JavaScript API. |
-| `load.key`                      | Browser Google Maps API key. Restrict it by HTTP referrer.                     |
-| `load.libraries`                | Extra Google Maps libraries such as `places`, `drawing`, or `visualization`.   |
-| `load.language` / `load.region` | Localize Google Maps controls and service responses.                           |
-| `excludeEventsOnAllComponents`  | Prevent selected Google Maps events from being emitted by all components.      |
+| Option                          | Purpose                                                                                                                                     |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dynamicLoad`                   | Install the plugin without immediately loading the Google Maps JavaScript API.                                                              |
+| `load.key`                      | Browser Google Maps API key. Restrict it by HTTP referrer.                                                                                  |
+| `load.libraries`                | Extra Google Maps libraries such as `places` or `visualization`. The `drawing` library was removed by Google in Maps JavaScript API v3.65+. |
+| `load.language` / `load.region` | Localize Google Maps controls and service responses.                                                                                        |
+| `excludeEventsOnAllComponents`  | Prevent selected Google Maps events from being emitted by all components.                                                                   |
 
 :::warning
 The browser API key is public. Do not commit unrestricted keys; use environment configuration for convenience and enforce restrictions in Google Cloud Console.
+:::
+
+:::warning Drawing Library removal
+Google deprecated the Maps JavaScript API Drawing Library and removed `google.maps.drawing.DrawingManager` in Maps JavaScript API v3.65+. `GmvDrawingManager` is kept only for legacy API versions where Google still serves the Drawing Library. For current Maps API versions, build drawing workflows with editable shapes, the Data layer/GeoJSON, or a third-party drawing library such as Terra Draw.
 :::
 
 ## Install example

--- a/packages/v2/src/components/drawing-manager.vue
+++ b/packages/v2/src/components/drawing-manager.vue
@@ -13,6 +13,11 @@ import MapElementMixin from '../mixins/map-element';
 import { drawingManagerMappedProps } from '../utils/mapped-props-by-map-element';
 import { bindProps, getPropsValues } from '../utils/helpers';
 
+const drawingLibraryUnavailableMessage =
+  '[GmapVue] The Google Maps JavaScript API Drawing Library is unavailable. ' +
+  'Google removed DrawingManager in Maps JavaScript API v3.65+. ' +
+  'Use editable Maps shapes, the Data layer/GeoJSON, or a third-party drawing library such as Terra Draw instead.';
+
 /**
  * DrawingManager component
  * @displayName GmapDrawingManager
@@ -61,6 +66,10 @@ export default {
           position,
         };
 
+        if (!google.maps.drawing || !google.maps.drawing.DrawingManager) {
+          throw new Error(drawingLibraryUnavailableMessage);
+        }
+
         // https://stackoverflow.com/questions/1606797/use-of-apply-with-new-operator-is-this-possible
         this.$drawingManagerObject = new google.maps.drawing.DrawingManager(
           finalOptions
@@ -81,6 +90,7 @@ export default {
         return this.$drawingManagerObject;
       })
       .catch((error) => {
+        console.error(error.message || error);
         throw error;
       });
 

--- a/packages/v2/src/components/drawing-manager.vue
+++ b/packages/v2/src/components/drawing-manager.vue
@@ -90,7 +90,6 @@ export default {
         return this.$drawingManagerObject;
       })
       .catch((error) => {
-        console.error(error.message || error);
         throw error;
       });
 

--- a/packages/v3/src/components/drawing-manager.vue
+++ b/packages/v3/src/components/drawing-manager.vue
@@ -124,8 +124,24 @@ provide(props.drawingKey ?? $drawingManagerPromise, promise);
 // eslint-disable-next-line vue/component-definition-name-casing
 defineOptions({ name: 'drawing-manager' });
 const excludedEvents = usePluginOptions()?.excludeEventsOnAllComponents?.();
+const drawingLibraryUnavailableMessage =
+  '[GmapVue] The Google Maps JavaScript API Drawing Library is unavailable. ' +
+  'Google removed DrawingManager in Maps JavaScript API v3.65+. ' +
+  'Use editable Maps shapes, the Data layer/GeoJSON, or a third-party drawing library such as Terra Draw instead.';
 let map: google.maps.Map | undefined;
 let selectedShape: google.maps.drawing.OverlayCompleteEvent | undefined;
+
+const createDrawingLibraryUnavailableError = (cause?: unknown) => {
+  const error = new Error(drawingLibraryUnavailableMessage);
+  error.name = 'GmapVueDrawingLibraryUnavailableError';
+
+  if (cause) {
+    (error as Error & { cause?: unknown }).cause = cause;
+  }
+
+  return error;
+};
+
 mapPromise
   .then(async (mapInstance) => {
     if (!mapInstance) {
@@ -134,13 +150,34 @@ mapPromise
 
     map = mapInstance;
 
+    let drawingLibrary: Partial<google.maps.DrawingLibrary>;
+    try {
+      drawingLibrary = (await google.maps.importLibrary(
+        'drawing',
+      )) as Partial<google.maps.DrawingLibrary>;
+    } catch (error: unknown) {
+      throw createDrawingLibraryUnavailableError(error);
+    }
+    const { DrawingManager } = drawingLibrary;
+    const OverlayType =
+      drawingLibrary.OverlayType ??
+      (
+        google.maps as unknown as {
+          drawing?: { OverlayType?: typeof google.maps.drawing.OverlayType };
+        }
+      ).drawing?.OverlayType;
+
+    if (!DrawingManager || !OverlayType) {
+      throw createDrawingLibraryUnavailableError();
+    }
+
     const defaultDrawingControlOptions = {
       drawingModes: [
-        google.maps.drawing.OverlayType.MARKER,
-        google.maps.drawing.OverlayType.CIRCLE,
-        google.maps.drawing.OverlayType.POLYGON,
-        google.maps.drawing.OverlayType.POLYLINE,
-        google.maps.drawing.OverlayType.RECTANGLE,
+        OverlayType.MARKER,
+        OverlayType.CIRCLE,
+        OverlayType.POLYGON,
+        OverlayType.POLYLINE,
+        OverlayType.RECTANGLE,
       ],
       position: google.maps.ControlPosition.TOP_CENTER,
     };
@@ -154,9 +191,6 @@ mapPromise
       ...props.options,
     };
 
-    const { DrawingManager } = (await google.maps.importLibrary(
-      'drawing',
-    )) as google.maps.DrawingLibrary;
     const drawingManager = new DrawingManager({
       ...drawingManagerOptions,
       drawingControlOptions: {
@@ -207,7 +241,12 @@ mapPromise
     drawingPromiseDeferred.resolve(drawingManager);
   })
   .catch((error: unknown) => {
-    throw error;
+    const drawingError =
+      error instanceof Error
+        ? error
+        : createDrawingLibraryUnavailableError(error);
+    console.error(drawingError.message);
+    drawingPromiseDeferred.reject?.(drawingError);
   });
 
 /*******************************************************************************
@@ -469,7 +508,8 @@ watch(
  * HOOKS
  ******************************************************************************/
 onUnmounted(async () => {
-  (await promise)?.setMap(null);
+  const drawingManager = await promise.catch(() => undefined);
+  drawingManager?.setMap(null);
   useDestroyPromisesOnUnmounted(props.drawingKey ?? $drawingManagerPromise);
 });
 

--- a/packages/v3/tests/drawing-manager.spec.ts
+++ b/packages/v3/tests/drawing-manager.spec.ts
@@ -1,6 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ComponentInstance } from 'vue';
+// @ts-expect-error Vue SFC imports are handled by Vite/Vitest.
 import DrawingManager from '../src/components/drawing-manager.vue';
 import * as composables from '../src/composables';
 import { useDestroyPromisesOnUnmounted } from '../src/composables';
@@ -14,6 +15,9 @@ import {
 describe('DrawingManager component', () => {
   let Map: MockComponentConstructorWithHTML;
 
+  const createMapMock = () =>
+    new (Map as unknown as new () => MockComponentConstructorWithHTML)();
+
   beforeEach(() => {
     ({ Map } = googleMock.maps.importLibrary());
     vi.stubGlobal('google', googleMock);
@@ -24,7 +28,7 @@ describe('DrawingManager component', () => {
       () =>
         ({
           exposed: {
-            mapPromise: Promise.resolve(new Map()),
+            mapPromise: Promise.resolve(createMapMock()),
           },
         }) as unknown as ComponentInstance<unknown>,
     );
@@ -32,7 +36,8 @@ describe('DrawingManager component', () => {
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('should be mounted successfully', async () => {
@@ -76,7 +81,7 @@ describe('DrawingManager component', () => {
     });
     expect(JSON.stringify(drawingValues.options)).toEqual(
       JSON.stringify({
-        map: new Map() as MockComponentConstructorWithHTML,
+        map: createMapMock(),
         ...propsInOptions,
         drawingControlOptions: {
           drawingModes: ['MARKER', 'CIRCLE', 'POLYGON', undefined, undefined],
@@ -84,9 +89,9 @@ describe('DrawingManager component', () => {
         },
       }),
     );
-    expect(
-      wrapper.getCurrentComponent().exposed.drawingManagerPromise,
-    ).toBeInstanceOf(Promise);
+    const exposed = wrapper.getCurrentComponent().exposed;
+    expect(exposed).not.toBeNull();
+    expect(exposed?.drawingManagerPromise).toBeInstanceOf(Promise);
     wrapper.unmount();
   });
 
@@ -120,6 +125,43 @@ describe('DrawingManager component', () => {
     expect(useDestroyPromisesOnUnmounted).toHaveBeenCalledOnce();
     expect(useDestroyPromisesOnUnmounted).toHaveBeenCalledWith(
       props.drawingKey,
+    );
+  });
+
+  it('should reject the drawing manager promise with an actionable error when the drawing library is unavailable', async () => {
+    // given
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {
+      return undefined;
+    });
+    const googleWithoutDrawingLibrary = {
+      ...googleMock,
+      maps: {
+        ...googleMock.maps,
+        importLibrary: vi.fn((library?: string) => {
+          if (library === 'drawing') {
+            return {};
+          }
+
+          return googleMock.maps.importLibrary();
+        }),
+        drawing: undefined,
+      },
+    };
+    vi.stubGlobal('google', googleWithoutDrawingLibrary);
+    const wrapper = mount(DrawingManager);
+    const exposed = wrapper.getCurrentComponent().exposed;
+    expect(exposed).not.toBeNull();
+    const rejectionExpectation = expect(
+      exposed?.drawingManagerPromise,
+    ).rejects.toThrow('DrawingManager in Maps JavaScript API v3.65+');
+
+    // when
+    await flushPromises();
+
+    // then
+    await rejectionExpectation;
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Drawing Library is unavailable'),
     );
   });
 });


### PR DESCRIPTION
Closes #374

## Summary

- Adds graceful runtime detection when Google Maps JavaScript API no longer provides the Drawing Library / `DrawingManager`.
- Rejects the Vue 3 drawing manager promise with an actionable error instead of failing with a cryptic `TypeError`.
- Documents that `GmvDrawingManager` / `GmapDrawingManager` are legacy-only because Google removed `google.maps.drawing.DrawingManager` in Maps JS API v3.65+.

## Changes

| File | Change |
| --- | --- |
| `packages/v3/src/components/drawing-manager.vue` | Guards `importLibrary('drawing')`, missing `DrawingManager`, and missing `OverlayType`; rejects the exposed promise with a clear error. |
| `packages/v2/src/components/drawing-manager.vue` | Adds a guard before constructing `google.maps.drawing.DrawingManager`. |
| `packages/v3/tests/drawing-manager.spec.ts` | Adds unavailable Drawing Library coverage and hardens mock cleanup. |
| `packages/documentation/docs/vue-3-version/api/02-gmap-vue-plugin.md` | Removes `drawing` from stable library guidance and adds a removal warning. |
| `packages/documentation/docs/vue-2-version/guide/drawing-manager.md` | Adds a Drawing Library removal warning. |
| `packages/documentation/docs/vue-2-version/code/components/drawing-manager.mdx` | Adds a Drawing Library removal warning. |

## Test plan

- [x] `cd packages/v3 && pnpm exec vitest run tests/drawing-manager.spec.ts`
- [x] `cd packages/v3 && pnpm run type-check`
- [x] `cd packages/v2 && pnpm run build`
- [x] `cd packages/documentation && pnpm run build`
- [x] `pnpm run lint && pnpm run test && pnpm run test:e2e`

## Notes

This does not add a new drawing implementation. Google did not provide a drop-in replacement for `DrawingManager`; a modern custom drawing tool or Terra Draw integration should be handled as a separate design/API change.