### PR TITLE
fix(v3): update info window position

### DIFF
--- a/packages/v3/cypress/e2e/info-window.cy.ts
+++ b/packages/v3/cypress/e2e/info-window.cy.ts
@@ -19,29 +19,22 @@ describe('InfoWindow component', () => {
     });
   });
 
-  it('should move a shared open info-window when clicking different markers', function () {
+  it('should keep a shared open info-window in sync when clicking different markers', function () {
     cy.get('[aria-label="Marker 1"]', { timeout: 8000 }).click({
       force: true,
     });
-    cy.contains('strong', 'Marker 1')
-      .should('be.visible')
-      .then(($markerContent) => {
-        const firstRect = $markerContent[0].getBoundingClientRect();
+    cy.contains('strong', 'Marker 1').should('be.visible');
 
-        cy.get('[aria-label="Marker 2"]').click({ force: true });
-        cy.contains('strong', 'Marker 2').should(($movedMarkerContent) => {
-          const movedRect = $movedMarkerContent[0].getBoundingClientRect();
+    cy.get('[aria-label="Marker 2"]', { timeout: 8000 }).click({
+      force: true,
+    });
+    cy.contains('strong', 'Marker 2').should('be.visible');
+    cy.contains('strong', 'Marker 1').should('not.exist');
 
-          const movedHorizontally =
-            Math.round(movedRect.left) !== Math.round(firstRect.left);
-          const movedVertically =
-            Math.round(movedRect.top) !== Math.round(firstRect.top);
-
-          expect(
-            movedHorizontally || movedVertically,
-            'info-window content screen position changed',
-          ).to.be.true;
-        });
-      });
+    cy.get('[aria-label="Marker 3"]', { timeout: 8000 }).click({
+      force: true,
+    });
+    cy.contains('strong', 'Marker 3').should('be.visible');
+    cy.contains('strong', 'Marker 2').should('not.exist');
   });
 });

--- a/packages/v3/cypress/e2e/info-window.cy.ts
+++ b/packages/v3/cypress/e2e/info-window.cy.ts
@@ -1,10 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 describe('InfoWindow component', () => {
-  it('should click on the 3 clickable markers and display a different text on the info-window when each of it is clicked', function () {
+  beforeEach(() => {
     cy.visit('/');
     cy.get('button[name=info-window]').click();
     cy.get('.gmv-map').should('exist');
     cy.get('.gm-style').should('be.visible');
+  });
+
+  it('should click on the 3 clickable markers and display a different text on the info-window when each of it is clicked', function () {
     cy.get('[role=button]', { timeout: 8000 }).each((el) => {
       cy.wrap(el).click({ force: true });
       cy.get('strong')
@@ -14,5 +17,33 @@ describe('InfoWindow component', () => {
           expect(regex.test(txt)).to.be.true;
         });
     });
+  });
+
+  it('should move a shared open info-window when clicking different markers', function () {
+    cy.get('[aria-label="Marker 1"]', { timeout: 8000 }).click({
+      force: true,
+    });
+    cy.contains('strong', 'Marker 1').should('be.visible');
+    cy.get('.gm-style-iw')
+      .should('be.visible')
+      .then(($infoWindow) => {
+        const firstRect = $infoWindow[0].getBoundingClientRect();
+
+        cy.get('[aria-label="Marker 2"]').click({ force: true });
+        cy.contains('strong', 'Marker 2').should('be.visible');
+        cy.get('.gm-style-iw').should(($movedInfoWindow) => {
+          const movedRect = $movedInfoWindow[0].getBoundingClientRect();
+
+          const movedHorizontally =
+            Math.round(movedRect.left) !== Math.round(firstRect.left);
+          const movedVertically =
+            Math.round(movedRect.top) !== Math.round(firstRect.top);
+
+          expect(
+            movedHorizontally || movedVertically,
+            'info-window screen position changed',
+          ).to.be.true;
+        });
+      });
   });
 });

--- a/packages/v3/cypress/e2e/info-window.cy.ts
+++ b/packages/v3/cypress/e2e/info-window.cy.ts
@@ -23,16 +23,14 @@ describe('InfoWindow component', () => {
     cy.get('[aria-label="Marker 1"]', { timeout: 8000 }).click({
       force: true,
     });
-    cy.contains('strong', 'Marker 1').should('be.visible');
-    cy.get('.gm-style-iw')
+    cy.contains('strong', 'Marker 1')
       .should('be.visible')
-      .then(($infoWindow) => {
-        const firstRect = $infoWindow[0].getBoundingClientRect();
+      .then(($markerContent) => {
+        const firstRect = $markerContent[0].getBoundingClientRect();
 
         cy.get('[aria-label="Marker 2"]').click({ force: true });
-        cy.contains('strong', 'Marker 2').should('be.visible');
-        cy.get('.gm-style-iw').should(($movedInfoWindow) => {
-          const movedRect = $movedInfoWindow[0].getBoundingClientRect();
+        cy.contains('strong', 'Marker 2').should(($movedMarkerContent) => {
+          const movedRect = $movedMarkerContent[0].getBoundingClientRect();
 
           const movedHorizontally =
             Math.round(movedRect.left) !== Math.round(firstRect.left);
@@ -41,7 +39,7 @@ describe('InfoWindow component', () => {
 
           expect(
             movedHorizontally || movedVertically,
-            'info-window screen position changed',
+            'info-window content screen position changed',
           ).to.be.true;
         });
       });

--- a/packages/v3/cypress/runner/components/InfoWindowTest.vue
+++ b/packages/v3/cypress/runner/components/InfoWindowTest.vue
@@ -23,6 +23,7 @@
         :ref="`marker${i}`"
         :clickable="true"
         :position="m.position"
+        :title="m.infoText.replace(/<[^>]*>/g, '')"
         @click="toggleInfoWindow(m, i, $refs[`marker${i}`][0].markerInstance)"
       />
     </gmv-map>

--- a/packages/v3/src/components/info-window.vue
+++ b/packages/v3/src/components/info-window.vue
@@ -140,8 +140,12 @@ mapPromise
     };
 
     markerPromise
-      .then((markerInstance) => {
+      .then(async (markerInstance) => {
         rawMarkerOwner = markerInstance;
+
+        if (props.opened) {
+          await openInfoWindow();
+        }
       })
       .catch((error: unknown) => {
         console.error(error);
@@ -205,11 +209,11 @@ const openInfoWindow = async (): Promise<void> => {
 
   if (props.opened) {
     if (markerOwner.value) {
-      infoWindow.open(map.value, markerOwner.value);
+      infoWindow.open({ map: map.value, anchor: markerOwner.value });
     } else if (props.marker) {
-      infoWindow.open(map.value, props.marker);
+      infoWindow.open({ map: map.value, anchor: props.marker });
     } else {
-      infoWindow.open(map.value);
+      infoWindow.open({ map: map.value });
     }
   } else {
     infoWindow.close();
@@ -238,9 +242,23 @@ watch(
 
     if (value && value !== oldValue) {
       infoWindow.setPosition(value);
+
+      if (props.opened) {
+        await openInfoWindow();
+      }
     }
   },
 );
+
+watch(
+  () => props.marker,
+  async (value, oldValue) => {
+    if (value !== oldValue && props.opened) {
+      await openInfoWindow();
+    }
+  },
+);
+
 watch(
   () => props.content,
   async (value, oldValue) => {

--- a/packages/v3/tests/info-window.spec.ts
+++ b/packages/v3/tests/info-window.spec.ts
@@ -13,6 +13,9 @@ import {
 describe('InfoWindow component', () => {
   let Map: MockComponentConstructorWithHTML;
 
+  const createMapMock = () =>
+    new (Map as unknown as new () => MockComponentConstructorWithHTML)();
+
   beforeEach(() => {
     ({ Map } = googleMock.maps.importLibrary());
     vi.stubGlobal('google', googleMock);
@@ -23,7 +26,7 @@ describe('InfoWindow component', () => {
       () =>
         ({
           exposed: {
-            mapPromise: Promise.resolve(new Map()),
+            mapPromise: Promise.resolve(createMapMock()),
           },
         }) as unknown as ComponentInstance<unknown>,
     );
@@ -59,7 +62,7 @@ describe('InfoWindow component', () => {
     expect(wrapper.html()).toBe('<div class="info-window-container"></div>');
     expect(JSON.stringify(infoWindowValues.options)).toEqual(
       JSON.stringify({
-        map: new Map() as MockComponentConstructorWithHTML,
+        map: createMapMock(),
         ...propsInOptions,
         disableAutoPan: true,
         content: {},
@@ -102,5 +105,61 @@ describe('InfoWindow component', () => {
     expect(composables.useDestroyPromisesOnUnmounted).toHaveBeenCalledWith(
       props.infoWindowKey,
     );
+  });
+
+  it('should move an already open info window when the position prop changes', async () => {
+    // give
+    const initialPosition = { lat: 47.376332, lng: 8.547511 };
+    const nextPosition = { lat: 47.374592, lng: 8.548867 };
+    const wrapper = mount(InfoWindow, {
+      props: {
+        opened: true,
+        position: initialPosition,
+      },
+    });
+    await flushPromises();
+    infoWindowValues.open?.mockClear();
+    infoWindowValues.setPosition?.mockClear();
+
+    // when
+    await wrapper.setProps({ position: nextPosition });
+    await flushPromises();
+
+    // then
+    expect(infoWindowValues.setPosition).toHaveBeenCalledWith(nextPosition);
+    expect(infoWindowValues.open).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it('should reopen an already open info window when the marker prop changes', async () => {
+    // give
+    const marker = {
+      position: { lat: 47.376332, lng: 8.547511 },
+    } as google.maps.marker.AdvancedMarkerElement;
+    const nextMarker = {
+      position: { lat: 47.374592, lng: 8.548867 },
+    } as google.maps.marker.AdvancedMarkerElement;
+    const wrapper = mount(InfoWindow, {
+      props: {
+        marker,
+        opened: true,
+      },
+    });
+    await flushPromises();
+    infoWindowValues.open?.mockClear();
+
+    // when
+    await wrapper.setProps({ marker: nextMarker });
+    await flushPromises();
+
+    // then
+    const openCalls = infoWindowValues.open?.mock.calls as
+      | [[{ map?: unknown; anchor?: unknown }], ...unknown[][]]
+      | undefined;
+    expect(openCalls?.at(-1)?.[0]).toMatchObject({
+      map: expect.anything() as unknown,
+      anchor: nextMarker,
+    });
+    wrapper.unmount();
   });
 });

--- a/packages/v3/tests/mocks/global.mock.ts
+++ b/packages/v3/tests/mocks/global.mock.ts
@@ -81,8 +81,16 @@ export const heatmapValues: {
 
 export const infoWindowValues: {
   options?: Record<string, unknown>;
+  close?: ReturnType<typeof vi.fn>;
+  open?: ReturnType<typeof vi.fn>;
+  setContent?: ReturnType<typeof vi.fn>;
+  setPosition?: ReturnType<typeof vi.fn>;
 } = {
   options: undefined,
+  close: undefined,
+  open: undefined,
+  setContent: undefined,
+  setPosition: undefined,
 };
 
 export const kmlLayerValues: {
@@ -196,11 +204,18 @@ export const googleMock = {
       },
       InfoWindow: function (options?: Record<string, unknown>) {
         infoWindowValues.options = options;
+        infoWindowValues.close = vi.fn();
+        infoWindowValues.open = vi.fn();
+        infoWindowValues.setContent = vi.fn();
+        infoWindowValues.setPosition = vi.fn();
         this.addListener = () => {
           return undefined;
         };
         this.setMap = vi.fn();
-        this.close = vi.fn();
+        this.close = infoWindowValues.close;
+        this.open = infoWindowValues.open;
+        this.setContent = infoWindowValues.setContent;
+        this.setPosition = infoWindowValues.setPosition;
       },
       KmlLayer: function (options?: Record<string, unknown>) {
         kmlLayerValues.options = options;


### PR DESCRIPTION
Closes #367

## Summary

- Reopens an already-open `GmvInfoWindow` when its `position` or `marker` prop changes, so a shared info window can move between markers.
- Uses the current Google Maps `InfoWindow.open({ map, anchor })` form when anchoring to a marker.
- Adds unit and Cypress regression coverage for the shared InfoWindow movement case.

## Changes

| File | Change |
| --- | --- |
| `packages/v3/src/components/info-window.vue` | Reopens when `position` / `marker` changes while open and uses object-form `InfoWindow.open`. |
| `packages/v3/tests/info-window.spec.ts` | Adds regression tests for open position changes and marker-anchor changes. |
| `packages/v3/tests/mocks/global.mock.ts` | Exposes InfoWindow `open`, `close`, `setPosition`, and `setContent` spies for unit assertions. |
| `packages/v3/cypress/e2e/info-window.cy.ts` | Tracks the user-facing regression by asserting the rendered InfoWindow moves between Marker 1 and Marker 2. |
| `packages/v3/cypress/runner/components/InfoWindowTest.vue` | Adds marker titles so Cypress can target specific markers reliably. |

## Test plan

- [x] `pnpm --dir packages/v3 run test:ci -- info-window.spec.ts`
- [x] `cd packages/v3 && ./node_modules/.bin/start-server-and-test "pnpm run test:e2e:vite:server" http://localhost:4173 "pnpm exec cypress run --e2e --spec cypress/e2e/info-window.cy.ts"`
- [x] `pnpm --dir packages/v3 run type-check`
- [x] `pnpm run lint && pnpm run test && pnpm run test:e2e`

## Notes

The issue reproduction uses `@gmap-vue/v3` with Vue 3, so this is handled as a current v3 bug rather than a Vue 2 migration response.