### PR TITLE
ci(docs): use workflow token for pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   publish-docs:
     name: github pages
@@ -40,4 +43,4 @@ jobs:
           # GitHub project pages serve the branch root at /gmap-vue/.
           build_dir: ./packages/documentation/build
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_REPO }}
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- grant `contents: write` to the documentation workflow
- use the built-in `${{ github.token }}` for the `gh-pages` push instead of the repo secret

## Why

The docs build succeeded after PR #379 merged, but the deploy failed while pushing to `gh-pages` with `Invalid username or token`. Using the workflow token avoids depending on a stale or misconfigured `GH_TOKEN_REPO` secret for same-repository Pages deployment.

## Validation

- parsed all workflow YAML files locally
