### PR TITLE
docs(docs): improve vue 3 map quickstart

### DIFF
--- a/packages/documentation/docs/vue-3-version/guide/basic-usage/map-reference.md
+++ b/packages/documentation/docs/vue-3-version/guide/basic-usage/map-reference.md
@@ -1,159 +1,128 @@
 ---
 id: map-reference
 sidebar_position: 2
-sidebar_label: Map Reference
+sidebar_label: Map reference
 ---
 
 # Getting a map reference
 
+Most map updates should use Vue state. Reach for the underlying `google.maps.Map` instance only when you need an imperative Google Maps method.
+
 ## Reactive props
 
-The `:center` prop on `GmvMap` and the `:position` prop on `GmvMarker` are **fully reactive**. Binding them to a reactive variable is all you need — updating the variable will automatically pan the map and move the marker with no imperative code required.
+The `:center` prop on `GmvMap` and the `:position` prop on `GmvMarker` are reactive. Binding them to reactive values is enough for normal data-driven updates.
 
-```html title="Composition API — reactive center & marker position" showLineNumbers
+```vue title="ReactiveMap.vue" showLineNumbers
+<script setup lang="ts">
+import { ref } from "vue";
+
+const center = ref({ lat: 1.32, lng: 103.8 });
+
+function moveToNewLocation() {
+  center.value = { lat: 1.38, lng: 103.8 };
+}
+</script>
+
 <template>
-  <GmvMap :center="center" :zoom="14">
+  <GmvMap :center="center" :zoom="14" style="width: 100%; height: 400px">
     <GmvMarker :position="center" />
   </GmvMap>
-  <button @click="moveTo">Move to new location</button>
+  <button @click="moveToNewLocation">Move to new location</button>
 </template>
-
-<script setup lang="ts">
-  import { ref } from "vue";
-
-  const center = ref({ lat: 1.32, lng: 103.8 });
-
-  function moveTo() {
-    center.value = { lat: 1.38, lng: 103.8 };
-    // The map and marker update automatically — no panTo() or markerPromise needed
-  }
-</script>
 ```
 
 :::note
-Only use `panTo()` / `markerPromise` for **programmatic animations** (e.g. smooth pan without updating the bound state). For data-driven position changes, always use reactive props.
+Use `panTo()` or other instance methods for programmatic interactions. For data-driven changes, prefer reactive props.
 :::
 
-## Accessing the map instance imperatively
+## Access the map with `map-key`
 
-If you need to gain access to the `Map` instance (e.g. to call `panToBounds`, `panTo`)
+Use `map-key` plus `useMapPromise()` when the parent component needs the map instance.
 
-```html title="Options API" showLineNumbers {2,22,26}
-<template>
-  <GmvMap ref="mapRef" class="map" :center="center" :zoom="7"></GmvMap>
-</template>
-<script lang="ts">
-  // import { type IMapLayerVueComponentExpose } from '@gmap-vue/v3/interfaces';
-
-  export default {
-    data() {
-      return {
-        center: {
-          lat: 1.32,
-          lng: 103.8,
-        },
-      };
-    },
-    mounted() {
-      // At this point, the child GmapMap has been mounted, but
-      // its map has not been initialized.
-      // Therefore we need to write mapRef.$mapPromise.then(() => ...)
-
-      // (this.$refs.mapRef as (typeof MapLayer & IMapLayerVueComponentExpose)).mapPromise // - useful to type the exposed method
-      this.$refs.mapRef.mapPromise?.then((map) => {
-        if (map) {
-          setTimeout(() => {
-            map.panTo({ lat: 1.0, lng: 100.0 });
-            console.log(this.$refs.mapRef);
-          }, 2000);
-        }
-      });
-    },
-  };
-</script>
-<style scoped>
-  .map {
-    height: 50vh;
-    width: 50vw;
-  }
-</style>
-```
-
-```html title="Composition API" showLineNumbers {2,10,11,17-24}
-<template>
-  <GmvMap ref="mapRef" class="map" :center="center" :zoom="7"></GmvMap>
-</template>
-
+```vue title="MapPromiseExample.vue" showLineNumbers
 <script setup lang="ts">
-  import { useMapPromise } from "@gmap-vue/v3/composables";
-  import { onMounted, ref } from "vue";
-  import { MapLayer } from "@gmap-vue/v3/components";
+import { useMapPromise } from "@gmap-vue/v3/composables";
+import { ref } from "vue";
 
-  const mapRef = ref<typeof MapLayer | null>(null);
-  const mapPromise = useMapPromise();
-  const center = {
-    lat: 1.32,
-    lng: 103.8,
-  };
-  onMounted(() => {
-    mapPromise?.then((map) => {
-      if (map) {
-        setTimeout(() => {
-          map.panTo({ lat: 1.0, lng: 100.0 });
-          console.log(mapRef.value);
-        }, 2000);
-      }
-    });
-  });
+const center = ref({ lat: 1.32, lng: 103.8 });
+const mapKey = "main-map";
+const mapPromise = useMapPromise(mapKey);
+
+async function panToLocation() {
+  const map = await mapPromise;
+  map?.panTo({ lat: 1.0, lng: 100.0 });
+}
 </script>
 
-<style scoped>
-  .map {
-    height: 50vh;
-    width: 50vw;
-  }
-</style>
+<template>
+  <GmvMap
+    :map-key="mapKey"
+    :center="center"
+    :zoom="7"
+    style="width: 100%; height: 400px"
+  />
+  <button @click="panToLocation">Pan map</button>
+</template>
 ```
 
-## Typing a component ref
+The string passed to `useMapPromise(mapKey)` must match the `map-key` prop. Use stable, unique keys when a page renders multiple maps.
 
-:::info
-To safety type a ref of one of the plugin components is to add the following to your `main.ts` file
+## Access the map with a component ref
 
-```ts title="main.ts" showLineNumbers {11}
-import { ComponentInstance } from "vue";
+`GmvMap` also exposes `mapPromise` through the component instance. This is useful when you already need a template ref.
+
+```vue title="MapRefExample.vue" showLineNumbers
+<script setup lang="ts">
 import { MapLayer } from "@gmap-vue/v3/components";
-import { type IMapLayerVueComponentExpose } from "@gmap-vue/v3/interfaces";
+import { onMounted, ref } from "vue";
 
-/**
- * Vue augmentations
- */
+const center = ref({ lat: 1.32, lng: 103.8 });
+const mapRef = ref<InstanceType<typeof MapLayer> | null>(null);
+
+onMounted(async () => {
+  const map = await mapRef.value?.mapPromise;
+  map?.panTo({ lat: 1.0, lng: 100.0 });
+});
+</script>
+
+<template>
+  <GmvMap ref="mapRef" :center="center" :zoom="7" style="width: 100%; height: 400px" />
+</template>
+```
+
+## Typing a component ref globally
+
+If you use Options API refs heavily, you can augment Vue's `$refs` typing. Most Composition API code can use the local `InstanceType<typeof MapLayer>` pattern shown above instead.
+
+```ts title="main.ts" showLineNumbers
+import { MapLayer } from "@gmap-vue/v3/components";
+
 declare module "vue" {
   interface ComponentCustomProperties {
     $refs: {
-      mapRef: ComponentInstance<typeof MapLayer & IMapLayerVueComponentExpose>;
+      mapRef: InstanceType<typeof MapLayer>;
     };
   }
 }
 ```
 
-:::
+## Why parent components should not inject the map promise
 
-## The `inject` issue
+`GmvMap` provides the default map promise to its descendants. A parent component cannot inject something that is provided by its child, because the child has not executed `provide()` yet.
 
-:::warning
-
-In this example you can not use the `inject` method to get the mapPromise as we show below
-
-```ts title="Composition API" showLineNumbers
+```ts title="This only works in descendants of GmvMap" showLineNumbers
 import { inject } from "vue";
 import { $mapPromise } from "@gmap-vue/v3/keys";
 
 const mapPromise = inject($mapPromise);
 ```
 
-Why not? because you can use `inject` in a child component, that means in any component that you put between `<GmvMap ref="mapRef" class="map" :center="center" :zoom="7"> ... </GmvMap>`.
+For parent components, use one of these instead:
 
-In the examples above our component is the parent of the `GmvMap` component and the `provide` function was not executed yet, and we can not `inject` something that is not `provided` yet. Simple but tricky in a simple overview.
+- `useMapPromise(mapKey)` with a matching `<GmvMap :map-key="mapKey" />`
+- a template ref and `mapRef.value?.mapPromise`
 
-:::
+## Related pages
+
+- [`GmvMap` guide](../components/map.md)
+- [Supported composables](/docs/vue-3-version/api/composables)

--- a/packages/documentation/docs/vue-3-version/guide/components/map.md
+++ b/packages/documentation/docs/vue-3-version/guide/components/map.md
@@ -12,17 +12,44 @@ The component is exported as `MapLayer` from `@gmap-vue/v3/components` and regis
 
 ## Basic usage
 
+Give the map an explicit width and height. Without height, the map can load but appear blank.
+
 ```vue showLineNumbers
 <script setup lang="ts">
 import { ref } from "vue";
 
-const center = ref({ lat: 10, lng: 10 });
+const center = ref({ lat: -34.6037, lng: -58.3816 });
 </script>
 
 <template>
-  <GmvMap :center="center" :zoom="7" style="width: 100%; height: 500px" />
+  <GmvMap :center="center" :zoom="12" style="width: 100%; height: 500px" />
 </template>
 ```
+
+## Use reactive props first
+
+For data-driven UI changes, update Vue state and let `GmvMap` sync the Google Maps instance.
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { ref } from "vue";
+
+const center = ref({ lat: -34.6037, lng: -58.3816 });
+const zoom = ref(12);
+
+function moveToRecoleta() {
+  center.value = { lat: -34.5875, lng: -58.3974 };
+  zoom.value = 14;
+}
+</script>
+
+<template>
+  <GmvMap :center="center" :zoom="zoom" style="width: 100%; height: 500px" />
+  <button @click="moveToRecoleta">Move to Recoleta</button>
+</template>
+```
+
+Use the imperative map instance only when you need methods that are not represented by Vue props yet.
 
 ## Access the map instance
 
@@ -30,20 +57,14 @@ Use a template ref or the `useMapPromise` composable when you need the Google Ma
 
 ```vue showLineNumbers
 <script setup lang="ts">
+import { useMapPromise } from "@gmap-vue/v3/composables";
 import { ref } from "vue";
-import {
-  useGoogleMapsApiPromiseLazy,
-  useMapPromise,
-} from "@gmap-vue/v3/composables";
 
-const center = ref({ lat: 10, lng: 10 });
+const center = ref({ lat: -34.6037, lng: -58.3816 });
 const mapKey = "main-map";
 const mapPromise = useMapPromise(mapKey);
 
 async function handleTilesLoaded(): Promise<void> {
-  const google = await useGoogleMapsApiPromiseLazy();
-  if (!google) return;
-
   const map = await mapPromise;
   if (!map) return;
 
@@ -57,50 +78,58 @@ async function handleTilesLoaded(): Promise<void> {
   <GmvMap
     :map-key="mapKey"
     :center="center"
-    :zoom="11"
+    :zoom="12"
     style="width: 100%; height: 500px"
     @tilesloaded="handleTilesLoaded"
   />
 </template>
 ```
 
-`getBounds()` can return `undefined` before the map is initialized or visible. The `tilesloaded` event is a safer place to read bounds, center, and zoom.
+The string passed to `useMapPromise(mapKey)` must match the map's `map-key` prop. `getBounds()` can return `undefined` before the map is initialized or visible, so map events such as `tilesloaded` are safer places to read bounds, center, and zoom.
 
 ## Use `PlacesService`
 
-Enable the `places` library in the plugin options before using `google.maps.places.PlacesService`.
+Enable the `places` library in the plugin options before using `google.maps.places.PlacesService`. `places` is the plugin default, but explicit configuration makes the dependency clear.
+
+```ts title="main.ts excerpt" showLineNumbers
+createGmapVuePlugin({
+  load: {
+    key: import.meta.env.VITE_GOOGLE_MAPS_API_KEY,
+    libraries: "places",
+  },
+});
+```
+
+Then use the map promise before interacting with the map. Trigger Places requests from explicit user actions or controlled state, not high-frequency map render events.
 
 ```vue showLineNumbers
 <script setup lang="ts">
-import { ref } from "vue";
 import {
   useGoogleMapsApiPromiseLazy,
   useMapPromise,
 } from "@gmap-vue/v3/composables";
+import { ref } from "vue";
 
-const center = ref({ lat: 10, lng: 10 });
-const zoom = ref(11);
+const center = ref({ lat: -34.6037, lng: -58.3816 });
 const mapKey = "places-map";
 const mapPromise = useMapPromise(mapKey);
 
 async function findPlace(): Promise<void> {
   const google = await useGoogleMapsApiPromiseLazy();
-  if (!google) return;
+  const map = await mapPromise;
+  if (!google || !map) return;
 
   const service = new google.maps.places.PlacesService(
     document.createElement("div"),
   );
-  const map = await mapPromise;
-  if (!map) return;
 
   service.findPlaceFromQuery(
     {
-      query: "Museum of Contemporary Art Australia",
+      query: "Teatro Colón Buenos Aires",
       fields: ["name", "geometry"],
     },
     (results, status) => {
-      const [firstResult] = results ?? [];
-      const location = firstResult?.geometry?.location;
+      const location = results?.[0]?.geometry?.location;
 
       if (status === google.maps.places.PlacesServiceStatus.OK && location) {
         map.setCenter(location);
@@ -114,14 +143,16 @@ async function findPlace(): Promise<void> {
   <GmvMap
     :map-key="mapKey"
     :center="center"
-    :zoom="zoom"
+    :zoom="12"
     style="width: 100%; height: 500px"
-    @tilesloaded="findPlace"
   />
+  <button @click="findPlace">Find Teatro Colón</button>
 </template>
 ```
 
-## Source code
+## Related pages
 
-- [Component source on GitHub](https://github.com/diegoazh/gmap-vue/blob/master/packages/v3/src/components/map-layer.vue)
+- [Quick start](../index.md)
+- [Map reference](../basic-usage/map-reference.md)
 - [Generated component API](/docs/vue-3-version/api/components/map#source-code)
+- [Component source on GitHub](https://github.com/diegoazh/gmap-vue/blob/master/packages/v3/src/components/map-layer.vue)

--- a/packages/documentation/docs/vue-3-version/guide/index.md
+++ b/packages/documentation/docs/vue-3-version/guide/index.md
@@ -1,31 +1,43 @@
 ---
 id: introduction
-title: Introduction
+title: Quick start
 sidebar_position: 1
-sidebar_label: Introduction
+sidebar_label: Quick start
 ---
 
-# Vue 3 guide
+# Vue 3 quick start
 
-GmapVue is a Vue 3 wrapper around the Google Maps JavaScript API. Start here for new applications.
+GmapVue wraps the Google Maps JavaScript API with Vue 3 components and composables. This guide gets a new app from install to a visible map.
 
-## What you get
+## 1. Install the package
 
-- Vue 3 components such as `GmvMap`, `GmvMarker`, and `GmvAutocomplete`.
-- Composition API helpers from `@gmap-vue/v3/composables`.
-- TypeScript declarations for documented package entrypoints.
+```bash
+pnpm add @gmap-vue/v3
+```
 
-## Get a Google Maps API key
+Use the equivalent command for your package manager if your app does not use pnpm.
 
-Create a key in Google Cloud Console by following the [Google Maps JavaScript API key guide](https://developers.google.com/maps/documentation/javascript/get-api-key).
+## 2. Create a Google Maps API key
+
+Create a browser key in Google Cloud Console by following the [Google Maps JavaScript API key guide](https://developers.google.com/maps/documentation/javascript/get-api-key).
 
 :::warning
 Browser keys are visible to users. Restrict your key by HTTP referrer, enable only the APIs you need, and rotate any unrestricted key that was committed or shared.
 :::
 
-## Install the plugin
+For Vite apps, put the key in an environment file:
 
-```ts title="main.ts" showLineNumbers {1-4,9-13}
+```env title=".env.local"
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_browser_key
+```
+
+`VITE_GOOGLE_MAPS_API_KEY` is convenient configuration, not a secret. Vite exposes `VITE_*` variables to browser code.
+
+## 3. Install the Vue plugin
+
+Register the plugin once in your app entrypoint and import the package stylesheet.
+
+```ts title="main.ts" showLineNumbers {1-2,9-14}
 import { createGmapVuePlugin } from "@gmap-vue/v3";
 import "@gmap-vue/v3/dist/style.css";
 import { createApp } from "vue";
@@ -45,10 +57,59 @@ app.use(
 app.mount("#app");
 ```
 
-`VITE_GOOGLE_MAPS_API_KEY` is a convenient Vite configuration value, not a secret. Vite exposes `VITE_*` variables to browser code.
+The plugin globally registers components such as `GmvMap`, `GmvMarker`, `GmvInfoWindow`, and `GmvAutocomplete`.
+
+## 4. Render your first map
+
+`GmvMap` needs an explicit size. If the container has no height, the map can initialize correctly but appear blank.
+
+```vue title="App.vue" showLineNumbers
+<script setup lang="ts">
+import { ref } from "vue";
+
+const center = ref({ lat: -34.6037, lng: -58.3816 });
+</script>
+
+<template>
+  <GmvMap :center="center" :zoom="12" style="width: 100%; height: 400px" />
+</template>
+```
+
+## 5. Access the map instance when needed
+
+For normal UI state, prefer reactive props such as `:center` and `:zoom`. Use the underlying `google.maps.Map` instance only when you need Google Maps methods that are not represented by Vue props yet.
+
+```vue title="MapInstanceExample.vue" showLineNumbers
+<script setup lang="ts">
+import { useMapPromise } from "@gmap-vue/v3/composables";
+import { ref } from "vue";
+
+const center = ref({ lat: -34.6037, lng: -58.3816 });
+const mapKey = "main-map";
+const mapPromise = useMapPromise(mapKey);
+
+async function panToObelisco() {
+  const map = await mapPromise;
+  map?.panTo({ lat: -34.6037, lng: -58.3816 });
+}
+</script>
+
+<template>
+  <GmvMap
+    :map-key="mapKey"
+    :center="center"
+    :zoom="12"
+    style="width: 100%; height: 400px"
+  />
+  <button @click="panToObelisco">Pan to Obelisco</button>
+</template>
+```
+
+The string passed to `useMapPromise(mapKey)` must match the map's `map-key` prop.
 
 ## Next steps
 
+- Learn the [`GmvMap` component](./components/map.md).
+- Learn [map instance access](./basic-usage/map-reference.md).
 - Review the [plugin options API](/docs/vue-3-version/api/gmap-vue-plugin#plugin-options).
-- Review the [component API](/docs/vue-3-version/api/components).
 - Use only the [supported package entrypoints](../api/#supported-entrypoints).

--- a/packages/documentation/docs/vue-3-version/guide/install-function.md
+++ b/packages/documentation/docs/vue-3-version/guide/install-function.md
@@ -6,94 +6,66 @@ sidebar_label: Install function
 
 # The install function
 
-The install function get the options passed to the plugin and process it to initialize the plugin.
+This page explains what `createGmapVuePlugin()` does when you call `app.use(...)`. For a first map, start with the [quick start](./index.md) instead.
 
-The install function loads the Google Maps API using a promise. This promise is returned by the `googleMapsApiPromiseLazy` function. This function is saved in a global property inside the `app` called `$gmapApiPromiseLazy` and you can use it to access it in the options API.
+## App-level state
 
-The install function also saves the options passed to the plugin in a global property called `$gmapOptions`. Both `$gmapOptions` and `$gmapApiPromiseLazy` are provided to the Vue app so Composition API helpers can read app-scoped state inside components.
+The install function receives your plugin options, merges them with defaults, and creates a lazy promise for the Google Maps JavaScript API.
 
-These two options also have its own composables functions that you can use to get their respective values using the Vue composition API. For more details go to the [next section](/docs/vue-3-version/guide/global-properties).
+The plugin exposes that state in two ways:
+
+- `app.config.globalProperties.$gmapApiPromiseLazy`
+- `app.config.globalProperties.$gmapOptions`
+- Vue `provide()` entries consumed by the Composition API helpers
 
 ```ts title="plugin main.ts" showLineNumbers
-// ...
 app.config.globalProperties.$gmapApiPromiseLazy = googleMapsApiPromiseLazy;
 app.config.globalProperties.$gmapOptions = finalOptions;
 app.provide($gmapOptions, finalOptions);
 app.provide($gmapApiPromiseLazy, googleMapsApiPromiseLazy);
-// ...
 ```
 
-Finally, by default the install function initialize and install all components in the plugin.
+Use the documented composables when you are writing Composition API code. See [global properties and composables](/docs/vue-3-version/guide/global-properties).
 
-```ts title="plugin main.ts" showLineNumbers
-// ...
-app
-  .component(
-    "GmvMap",
-    defineAsyncComponent(() => import("./components/map-layer.vue")),
-  )
-  .component(
-    "GmvMarker",
-    defineAsyncComponent(() => import("./components/marker-icon.vue")),
-  )
-  .component(
-    "GmvInfoWindow",
-    defineAsyncComponent(() => import("./components/info-window.vue")),
-  )
-  .component(
-    "GmvKmlLayer",
-    defineAsyncComponent(() => import("./components/kml-layer.vue")),
-  )
-  .component(
-    "GmvAutocomplete",
-    defineAsyncComponent(() => import("./components/autocomplete-input.vue")),
-  )
-  .component(
-    "GmvStreetViewPanorama",
-    defineAsyncComponent(() => import("./components/street-view-panorama.vue")),
-  )
-  .component(
-    "GmvHeatmapLayer",
-    defineAsyncComponent(() => import("./components/heatmap-layer.vue")),
-  )
-  .component(
-    "GmvCircle",
-    defineAsyncComponent(() => import("./components/circle-shape.vue")),
-  )
-  .component(
-    "GmvPolygon",
-    defineAsyncComponent(() => import("./components/polygon-shape.vue")),
-  )
-  .component(
-    "GmvPolyline",
-    defineAsyncComponent(() => import("./components/polyline-shape.vue")),
-  )
-  .component(
-    "GmvRectangle",
-    defineAsyncComponent(() => import("./components/rectangle-shape.vue")),
-  )
-  .component(
-    "GmvDrawingManager",
-    defineAsyncComponent(() => import("./components/drawing-manager.vue")),
-  )
-  .component(
-    "GmvCluster",
-    defineAsyncComponent(() => import("./components/cluster-icon.vue")),
-  );
+## Default Google Maps libraries
 
-// ...
+The plugin defaults `load.libraries` to `"places"`. Set the option explicitly when your app needs additional libraries.
+
+```ts title="main.ts" showLineNumbers
+app.use(
+  createGmapVuePlugin({
+    load: {
+      key: import.meta.env.VITE_GOOGLE_MAPS_API_KEY,
+      libraries: "places,visualization",
+    },
+  }),
+);
 ```
+
+Prefer comma-separated strings in public app code because the plugin option type documents `libraries` as a string.
+
+## Global components
+
+By default, the plugin registers all Vue components globally and lazy-loads their implementation.
+
+Common global names include:
+
+- `GmvMap`
+- `GmvMarker`
+- `GmvInfoWindow`
+- `GmvAutocomplete`
+- `GmvCircle`, `GmvPolygon`, `GmvPolyline`, `GmvRectangle`
+- `GmvHeatmapLayer`, `GmvKmlLayer`, `GmvStreetViewPanorama`
+- `GmvCluster`
+
+See the [components entrypoint](/docs/vue-3-version/api/components) for the full export-to-global-name mapping.
 
 :::note
-
-- As you can see above all components are **lazy loaded**
-- Now the **`GmvCluster`** component is **registered by default**, remember to install the `"@googlemaps/markerclusterer": "^2.5.3"` package
-
+`GmvCluster` is registered by default. The package already depends on `@googlemaps/markerclusterer`, so app users normally do not need to install it separately.
 :::
 
-:::info
+## Related API pages
 
-- Check the install function API [here](/docs/vue-3-version/api/gmap-vue-plugin)
-- Check the global properties and composables guide [here](/docs/vue-3-version/guide/global-properties)
-
-:::
+- [Plugin API](/docs/vue-3-version/api/gmap-vue-plugin)
+- [Supported package entrypoints](/docs/vue-3-version/api/#supported-entrypoints)
+- [Components API](/docs/vue-3-version/api/components)


### PR DESCRIPTION
## Summary

- expand the Vue 3 quick start with install, `.env.local`, plugin setup, CSS import, first map, and map-instance access
- clarify what the install function provides and how default components/libraries work
- improve the `GmvMap` guide with reactive-prop guidance, safer map instance examples, and an explicit PlacesService button example
- rewrite map-reference examples around `map-key`, `useMapPromise`, component refs, and the parent/child inject caveat

## Validation

- pnpm run --filter docs typecheck
- pnpm run --filter docs build
- pnpm run lint

## Review notes

A fresh reviewer caught that a PlacesService example originally used `@tilesloaded`, which could repeatedly call Places and incur cost. The final version uses an explicit button click instead.

`research.md` remains untracked and is not part of this PR.
