### PR TITLE
ci(root): use corepack for pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,5 @@
 name: ci
 
-env:
-  # Keep JavaScript actions on the upcoming GitHub Actions runtime. This avoids
-  # Node 20 action-runtime deprecation noise while the project itself tests the
-  # Node versions declared in the matrix below.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   pull_request:
     branches:
@@ -24,15 +18,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-          cache: "pnpm"
+      - name: Enable pnpm with Corepack
+        run: corepack enable
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Upload pnpm-lock.yaml as artifact
@@ -50,15 +41,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-          cache: "pnpm"
+      - name: Enable pnpm with Corepack
+        run: corepack enable
       - name: Download pnpm-lock.yaml artifact
         uses: actions/download-artifact@v8
         with:
@@ -109,14 +97,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Enable pnpm with Corepack
+        run: corepack enable
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Create env file

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,8 +1,5 @@
 name: documentation
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   push:
     branches:
@@ -18,15 +15,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
       - name: Use Node.js 22
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-          cache: "pnpm"
+      - name: Enable pnpm with Corepack
+        run: corepack enable
       - name: Install dependencies
         # Keep the root workspace visible so workspace-level pnpm policy applies.
         # Ignore workspace lifecycle hooks; docs validation does not need them.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: release
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 on:
   workflow_dispatch:
     inputs:
@@ -44,15 +41,12 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24.x
-          cache: "pnpm"
+      - name: Enable pnpm with Corepack
+        run: corepack enable
       - name: Upgrade npm for trusted publishing
         run: npm install --global npm@11
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- remove `pnpm/action-setup@v4` from all workflows
- use Node setup plus `corepack enable` so CI reads pnpm from `packageManager`
- remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`, which still produced annotations

## Why

GitHub Actions annotates `pnpm/action-setup@v4` because it targets Node.js 20. Using Corepack avoids that action entirely and should keep future pnpm upgrades tied to `package.json` instead of workflow-specific action behavior.

## Validation

- parsed all workflow YAML files locally
- confirmed no remaining `pnpm/action-setup` or `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` references
- `corepack enable && pnpm --version` resolves pnpm 11.7.0
- `pnpm install --frozen-lockfile --ignore-scripts`
