### PR TITLE
docs(docs): improve vue 3 autocomplete guide

### DIFF
--- a/packages/documentation/docs/vue-3-version/api/04-composables.md
+++ b/packages/documentation/docs/vue-3-version/api/04-composables.md
@@ -218,6 +218,39 @@ promiseDeferred.resolve(mapInstance);
 If the Map object was not loaded yet the composable function returns `undefined`.
 :::
 
+## `useAutocompletePromise`
+
+This composable returns a promise that resolves to the underlying `google.maps.places.Autocomplete` instance for a `GmvAutocomplete` component.
+
+For one autocomplete instance, you can call it without arguments. When coordinating multiple instances, use the same key that you pass to the component's `autocomplete-key` prop.
+
+```vue title="AutocompletePromiseExample.vue" showLineNumbers
+<script setup lang="ts">
+import { useAutocompletePromise } from "@gmap-vue/v3/composables";
+
+const autocompleteKey = "header-search";
+const autocompletePromise = useAutocompletePromise(autocompleteKey);
+
+async function readBounds() {
+  const autocomplete = await autocompletePromise;
+  console.log(autocomplete?.getBounds());
+}
+</script>
+
+<template>
+  <GmvAutocomplete :autocomplete-key="autocompleteKey" placeholder="Search" />
+  <button @click="readBounds">Read bounds</button>
+</template>
+```
+
+```ts title="How to use it" showLineNumbers
+export function useAutocompletePromise(
+  key: string | InjectionKey<Promise<google.maps.places.Autocomplete | undefined>> = $autocompletePromise,
+): Promise<google.maps.places.Autocomplete | undefined> {
+  return usePromise<google.maps.places.Autocomplete>(key);
+}
+```
+
 ## `useStreetViewPanoramaPromise`
 
 :::warning

--- a/packages/documentation/docs/vue-3-version/api/components/autocomplete.md
+++ b/packages/documentation/docs/vue-3-version/api/components/autocomplete.md
@@ -13,341 +13,109 @@ sidebar_label: Autocomplete
 
 :::
 
-This component is a wrapper of the Google Autocomplete class.
+`GmvAutocomplete` wraps the Google Maps Places Autocomplete widget. It creates a `google.maps.places.Autocomplete` instance for an input element and emits the selected `PlaceResult` through `place_changed`.
 
-:::note From the authors
-> Autocomplete is a feature of the Places library in the Maps JavaScript API. You can use autocomplete to give your applications the type-ahead-search behavior of the Google Maps search field. The autocomplete service can match on full words and substrings, resolving place names, addresses, and plus codes. Applications can therefore send queries as the user types, to provide on-the-fly place predictions. [reference](https://developers.google.com/maps/documentation/javascript/place-autocomplete#introduction)
-:::
+The component is exported as `Autocomplete` from `@gmap-vue/v3/components` and registered by the plugin as `GmvAutocomplete`.
+
+## Required Google Maps library
+
+The component imports the Places library internally:
+
+```ts showLineNumbers
+const { Autocomplete } = (await google.maps.importLibrary(
+  "places",
+)) as google.maps.PlacesLibrary;
+```
+
+The plugin defaults `load.libraries` to `"places"`, but if your app overrides `load.libraries`, keep `places` in the comma-separated list.
 
 ## Props
 
-:::info
-The _highlighted_ lines are the official props, we strongly recommend to read the [**official documentation**](https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions).
+Official Google options are passed to the Google Autocomplete instance. Plugin-specific props handle the input slot and promise registry.
 
-**Here we only describe the custom props added by this plugin**
-:::
-
-```ts title="Autocomplete props interface" showLineNumbers {11-15}
-/**
- * Autocomplete input Google Maps properties documentation
- *
- * @see https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions.bounds
- * @see https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions.componentRestrictions
- * @see https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions.fields
- * @see https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions.strictBounds
- * @see https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions.types
- */
+```ts title="Autocomplete props interface" showLineNumbers
 export interface IAutoCompleteInputVueComponentProps {
   bounds?: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral;
   componentRestrictions?: google.maps.places.ComponentRestrictions;
   fields?: string[];
   strictBounds?: boolean;
   types?: string[];
-  /**
-   * Select the first result in the list when press enter keyboard
-   * @values true, false
-   */
   selectFirstOnEnter?: boolean;
-  /**
-   * the unique ref set to the component passed in the slot input
-   */
   slotRef?: HTMLInputElement;
-  /**
-   * To avoid paying for data that you don't need,
-   * be sure to use Autocomplete.setFields() to specify
-   * only the place data that you will use.
-   *
-   * @see [Place information](https://developers.google.com/maps/documentation/javascript/places-autocomplete#get-place-information)
-   * @see [setFields](https://developers.google.com/maps/documentation/javascript/reference/places-widget#Autocomplete.setFields)
-   * @see [PlaceResult](https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult)
-   */
   setFieldsTo?: string[];
   autocompleteKey?: string;
   options?: Record<string, unknown>;
 }
 ```
 
-- **selectFirstOnEnter**:
-  - _type_: `boolean`
-  - _description_: Select the first result in the list when press enter keyboard
-- **slotRef**:
-  - _type_: `HTMLInputElement`
-  - _description_: the unique ref set to the component passed in the slot input
-- **setFieldsTo**: To avoid paying for data that you don't need, be sure to use Autocomplete.setFields() to specify only the place data that you will use.
-- **autocompleteKey**: This is used to identify every instance of the Google Maps Autocomplete class. If it's not provided it always use the `$autocompletePromise` key as its default value, but take care about it because if you use it in many places you will use always the same instance.
-- **options**:
-  - _type_: `Record<string, unknown>`
-  - _description_: We use this prop as a fallback option. If the official API changes and add new props to the class you can use the options prop to use and populate these new props until we update our API to use it explicitly.
+| Prop | Type | Description |
+| --- | --- | --- |
+| `bounds` | `google.maps.LatLngBounds \| google.maps.LatLngBoundsLiteral` | Bias predictions toward a map bounds area. |
+| `componentRestrictions` | `google.maps.places.ComponentRestrictions` | Restrict predictions by country or countries. |
+| `fields` | `string[]` | Fields requested in the constructor options. |
+| `strictBounds` | `boolean` | Restrict predictions to the configured bounds. |
+| `types` | `string[]` | Restrict prediction types, such as `geocode`. |
+| `selectFirstOnEnter` | `boolean` | Select the first prediction when the user presses Enter. Defaults to `true`. |
+| `slotRef` | `HTMLInputElement` | Real input element to use when rendering a custom slot. |
+| `setFieldsTo` | `string[]` | Calls `autocomplete.setFields()` after creation. Use it to request only the Place fields you need. |
+| `autocompleteKey` | `string` | Promise key used by `useAutocompletePromise(key)`. Use unique keys for multiple instances. |
+| `options` | `Record<string, unknown>` | Fallback for Google options not yet represented by explicit props. |
 
-## Exposed const
-
-:::note
-We only document the exposed methods of the component
+:::tip
+Use `fields` or `setFieldsTo` to limit the returned Place data. Requesting broad field sets can increase Places data usage and billing.
 :::
 
-- **autoCompletePromise**:
-  - _type_: [`Promise<InstanceType<google.maps.places.Autocomplete> | undefined>`](https://developers.google.com/maps/documentation/javascript/reference/places-widget#Autocomplete)
-  - _description_: This is a promise that resolves the instance of the Google Maps Autocomplete class.
+## Exposed properties
+
+`GmvAutocomplete` exposes a promise for the Google instance.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `autocompletePromise` | `Promise<google.maps.places.Autocomplete \| undefined>` | Resolves to the underlying Google Autocomplete instance. |
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { Autocomplete } from "@gmap-vue/v3/components";
+import { ref } from "vue";
+
+const autocompleteRef = ref<InstanceType<typeof Autocomplete> | null>(null);
+
+async function readBounds() {
+  const autocomplete = await autocompleteRef.value?.autocompletePromise;
+  console.log(autocomplete?.getBounds());
+}
+</script>
+
+<template>
+  <GmvAutocomplete ref="autocompleteRef" placeholder="Search" />
+  <button @click="readBounds">Read bounds</button>
+</template>
+```
 
 ## Events
 
-- **place_changed**:
-  - _Event type_: [`google.maps.places.PlaceResult`](https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult)
-  - _description_: This event is fired when a PlaceResult is made available for a Place the user has selected.
-If the user enters the name of a Place that was not suggested by the control and presses the Enter key, or if a Place Details request fails, the PlaceResult contains the user input in the name property, with no other properties defined.
+| Event | Payload | Description |
+| --- | --- | --- |
+| `place_changed` | `google.maps.places.PlaceResult` | Fired when the user selects a place. The payload is the result of `autocomplete.getPlace()`. |
+
+If the user enters text that was not selected from predictions, the `PlaceResult` may contain only limited data, such as the user input in `name`.
 
 ## Slots
 
-- **default**: It provides a fallback content if you don't provide a slot content
+The default slot receives forwarded attributes and should render an actual input element. Prefer the built-in input unless you have tested a custom slot in your app.
 
-```html showLineNumbers {3-5}
+```vue showLineNumbers
 <template>
-  <div>
-    <slot :attrs="$attrs">
-      <input ref="gmvAutoCompleteInput" v-bind="$attrs" />
-    </slot>
-  </div>
+  <slot :attrs="$attrs">
+    <input ref="gmvAutoCompleteInputRef" v-bind="$attrs" />
+  </slot>
 </template>
 ```
 
-## Source code
+Custom slots are advanced because the component needs a real `HTMLInputElement` through `slotRef` by the time `GmvAutocomplete` mounts. A normal parent template ref can be populated too late for the current mount flow.
 
-<details>
-  <summary>`autocomplete-input.vue` source code</summary>
+## Related APIs
 
-```html showLineNumbers
-<template>
-  <div>
-    <!--
-				@slot Used to set your custom component for the input, eg: v-text-field.
-        It has two binding properties:
-        - `attrs`, it's type is `object`, it's all attributes passed to the component ([vm.$attrs](https://vuejs.org/v2/api/?#vm-attrs))<br>
-			-->
-    <slot :attrs="$attrs">
-      <input ref="gmvAutoCompleteInput" v-bind="$attrs" />
-    </slot>
-  </div>
-</template>
-
-<script lang="ts" setup>
-import {
-  bindGoogleMapsEventsToVueEventsOnSetup,
-  bindPropsWithGoogleMapsSettersAndGettersOnSetup,
-  downArrowSimulator,
-  getComponentEventsConfig,
-  getComponentPropsConfig,
-  getPropsValuesWithoutOptionsProp,
-  useComponentPromiseFactory,
-  useDestroyPromisesOnUnmounted,
-  useGoogleMapsApiPromiseLazy,
-  usePluginOptions,
-} from '@/composables';
-import type { IAutoCompleteInputVueComponentProps } from '@/interfaces';
-import { $autocompletePromise } from '@/keys';
-import { onMounted, onUnmounted, provide, ref, watch } from 'vue';
-
-/**
- * Autocomplete component
- * @displayName GmvAutocomplete
- * @see [official guide](https://developers.google.com/maps/documentation/javascript/place-autocomplete)
- * @see [official reference](https://developers.google.com/maps/documentation/javascript/reference/places-widget#Autocomplete)
- * @see [source code](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/api/components/autocomplete)
- */
-
-/*******************************************************************************
- * DEFINE COMPONENT PROPS
- ******************************************************************************/
-const props = withDefaults(
-  defineProps<{
-    bounds?: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral;
-    componentRestrictions?: google.maps.places.ComponentRestrictions;
-    fields?: string[];
-    strictBounds?: boolean;
-    types?: string[];
-    /**
-     * Select the first result in the list when press enter keyboard
-     * @values true, false
-     */
-    selectFirstOnEnter?: boolean;
-    /**
-     * the unique ref set to the component passed in the slot input
-     */
-    slotRef?: HTMLInputElement;
-    /**
-     * To avoid paying for data that you don't need,
-     * be sure to use Autocomplete.setFields() to specify
-     * only the place data that you will use.
-     *
-     * @see [Place information](https://developers.google.com/maps/documentation/javascript/places-autocomplete#get-place-information)
-     * @see [setFields](https://developers.google.com/maps/documentation/javascript/reference/places-widget#Autocomplete.setFields)
-     * @see [PlaceResult](https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult)
-     */
-    setFieldsTo?: string[];
-    autocompleteKey?: string;
-    options?: Record<string, unknown>;
-  }>(),
-  {
-    selectFirstOnEnter: true,
-  },
-);
-
-/*******************************************************************************
- * TEMPLATE REF, ATTRIBUTES, EMITTERS AND SLOTS
- ******************************************************************************/
-const gmvAutoCompleteInput = ref<HTMLInputElement | null>(null);
-const emits = defineEmits<{
-  place_changed: [value: google.maps.places.PlaceResult];
-}>();
-
-/*******************************************************************************
- * INJECT
- ******************************************************************************/
-
-/*******************************************************************************
- * AUTOCOMPLETE
- ******************************************************************************/
-defineOptions({ inheritAttrs: false, name: 'autocomplete-input' });
-const excludedEvents = usePluginOptions()?.excludeEventsOnAllComponents?.();
-
-/*******************************************************************************
- * PROVIDE
- ******************************************************************************/
-const { promiseDeferred: autocompletePromiseDeferred, promise } =
-  useComponentPromiseFactory(props.autocompleteKey || $autocompletePromise);
-provide(props.autocompleteKey || $autocompletePromise, promise);
-
-/*******************************************************************************
- * COMPUTED
- ******************************************************************************/
-
-/*******************************************************************************
- * METHODS
- ******************************************************************************/
-
-/*******************************************************************************
- * WATCHERS
- ******************************************************************************/
-watch(
-  () => props.componentRestrictions,
-  async (newValue, oldValue) => {
-    const autocomplete = await promise;
-
-    if (!autocomplete) {
-      return console.error('the autocomplete instance is not defined');
-    }
-
-    if (newValue && newValue !== oldValue) {
-      autocomplete.setComponentRestrictions(newValue);
-    }
-  },
-);
-
-/*******************************************************************************
- * HOOKS
- ******************************************************************************/
-onMounted(() => {
-  useGoogleMapsApiPromiseLazy()
-    .then(async () => {
-      let scopedInput = props.slotRef
-        ? props.slotRef
-        : gmvAutoCompleteInput.value;
-
-      if (!scopedInput) {
-        throw new Error(
-          `we can find the template ref: 'gmvAutoCompleteInput' or we can't use the slotRef prop`,
-        );
-      }
-
-      if (props.selectFirstOnEnter) {
-        downArrowSimulator(scopedInput);
-      }
-
-      const autocompleteOptions: IAutoCompleteInputVueComponentProps & {
-        [key: string]: any;
-      } = {
-        ...getPropsValuesWithoutOptionsProp(props),
-        ...props.options,
-      };
-
-      const { Autocomplete } = (await google.maps.importLibrary(
-        'places',
-      )) as google.maps.PlacesLibrary;
-
-      if (typeof Autocomplete !== 'function') {
-        throw new Error(
-          "google.maps.places.Autocomplete is undefined. Did you add 'places' to libraries when loading Google Maps?",
-        );
-      }
-
-      const autocomplete = new Autocomplete(scopedInput, autocompleteOptions);
-
-      const autocompletePropsConfig =
-        getComponentPropsConfig('GmvAutocomplete');
-      const autocompleteEventsConfig = getComponentEventsConfig(
-        'GmvAutocomplete',
-        'auto',
-      );
-
-      bindPropsWithGoogleMapsSettersAndGettersOnSetup(
-        autocompletePropsConfig,
-        autocomplete,
-        emits as any,
-        props,
-      );
-
-      bindGoogleMapsEventsToVueEventsOnSetup(
-        autocompleteEventsConfig,
-        autocomplete,
-        emits as any,
-        excludedEvents,
-      );
-
-      if (props.setFieldsTo) {
-        autocomplete.setFields(props.setFieldsTo);
-      }
-
-      /**
-       * Not using `bindEvents` because we also want
-       * to return the result of `getPlace()`
-       */
-      autocomplete.addListener('place_changed', () => {
-        if (autocomplete) {
-          /**
-           * Place change event
-           * @event place_changed
-           * @property {object} place `this.$autocomplete.getPlace()`
-           * @see [Get place information](https://developers.google.com/maps/documentation/javascript/places-autocomplete#get-place-information)
-           */
-          emits('place_changed', autocomplete.getPlace());
-        }
-      });
-
-      if (!autocompletePromiseDeferred.resolve) {
-        throw new Error('autocompletePromiseDeferred.resolve is undefined');
-      }
-
-      autocompletePromiseDeferred.resolve(autocomplete);
-    })
-    .catch((error) => {
-      throw error;
-    });
-});
-
-onUnmounted(() => {
-  useDestroyPromisesOnUnmounted(props.autocompleteKey || $autocompletePromise);
-});
-
-/*******************************************************************************
- * RENDERS
- ******************************************************************************/
-
-/*******************************************************************************
- * EXPOSE
- ******************************************************************************/
-defineExpose({
-  autocompletePromise: promise,
-});
-</script>
-```
-
-</details>
+- [`useAutocompletePromise`](/docs/vue-3-version/api/composables#useautocompletepromise)
+- [User guide](/docs/vue-3-version/guide/components/autocomplete)
+- [Google PlaceResult reference](https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult)

--- a/packages/documentation/docs/vue-3-version/guide/components/autocomplete.md
+++ b/packages/documentation/docs/vue-3-version/guide/components/autocomplete.md
@@ -6,111 +6,150 @@ sidebar_label: Autocomplete
 
 # Autocomplete
 
-This component helps you to find and select a place on Google Maps API. For more information read the Google Maps documentation for [autocomplete](https://developers.google.com/maps/documentation/javascript/places-autocomplete).
+`GmvAutocomplete` wraps the Google Maps Places Autocomplete widget. It renders an input, creates a `google.maps.places.Autocomplete` instance, and emits the selected `PlaceResult` through `place_changed`.
 
-It is exported with the name `Autocomplete`, it is registered as `GmvAutocomplete`.
+The component is exported as `Autocomplete` from `@gmap-vue/v3/components` and registered by the plugin as `GmvAutocomplete`.
 
-## Autocomplete instance
+## Enable the Places library
 
-This component save the original autocomplete object provided by Google Maps in a property called `autoCompleteInstance`, as the example below.
+`GmvAutocomplete` calls `google.maps.importLibrary("places")`. The plugin defaults `load.libraries` to `"places"`, but if you override libraries you must keep `places` included.
 
-```ts showLineNumbers
-// ...
-const { Autocomplete } = (await google.maps.importLibrary(
-  'places',
-)) as google.maps.PlacesLibrary;
+```ts title="main.ts excerpt" showLineNumbers
+createGmapVuePlugin({
+  load: {
+    key: import.meta.env.VITE_GOOGLE_MAPS_API_KEY,
+    libraries: "places",
+  },
+});
+```
 
-if (typeof Autocomplete !== 'function') {
-  throw new Error(
-    "google.maps.places.Autocomplete is undefined. Did you add 'places' to libraries when loading Google Maps?",
-  );
+When combining libraries, use a comma-separated string:
+
+```ts title="main.ts excerpt" showLineNumbers
+libraries: "places,visualization";
+```
+
+## Basic usage
+
+Use `@place_changed` to receive the `google.maps.places.PlaceResult` selected by the user.
+
+```vue title="AutocompleteExample.vue" showLineNumbers
+<script setup lang="ts">
+function handlePlaceChanged(place: google.maps.places.PlaceResult) {
+  console.log("selected place", place.name, place.geometry?.location?.toJSON());
 }
+</script>
 
-const autocomplete = new Autocomplete(scopedInput, autocompleteOptions);
-// ...
-```
-
-## Source code
-
-You can see the source code on:
-
-- [GitHub](https://github.com/diegoazh/gmap-vue/blob/2c697bb5ae78e5519d95f4873f1ab373e3d25ff9/packages/v3/src/components/autocomplete-input.vue)
-- [Here in docs](/docs/vue-3-version/api/components/autocomplete#source-code)
-
-## How to use it
-
-```html showLineNumbers
 <template>
-  <!-- you can use the auto close form if you don't use the slot -->
-  <gmv-autocomplete />
-  <!-- <gmv-autocomplete></gmv-autocomplete> -->
-
-  <gmv-map :center="center" :zoom="7" style="width: 100%; height: 500px">
-  </gmv-map>
+  <GmvAutocomplete
+    placeholder="Search for a place"
+    :set-fields-to="['place_id', 'name', 'formatted_address', 'geometry']"
+    @place_changed="handlePlaceChanged"
+  />
 </template>
 ```
-
-```html showLineNumbers
-<template>
-  <!-- or use it with a slot -->
-  <GmvAutocomplete></GmvAutocomplete>
-  <!-- <GmvAutocomplete /> -->
-
-  <gmv-map :center="center" :zoom="7" style="width: 100%; height: 500px">
-  </gmv-map>
-</template>
-```
-
-## Customizing your text field
 
 :::tip
-The autocomplete supports custom text field via scoped slot
-
-```html showLineNumbers
-<gmv-autocomplete class="introInput">
-  <template v-slot:default="slotProps">
-    <v-text-field
-      outlined
-      prepend-inner-icon="place"
-      placeholder="Location Of Event"
-      ref="input"
-      v-bind:attrs="slotProps.attrs"
-    >
-    </v-text-field>
-  </template>
-</gmv-autocomplete>
-```
-
-The ref on the element must be unique. If you create more than one autocomplete, each one should have a unique ref and it must be mentioned in the slot-ref-name prop. Like this:
-
-```html showLineNumbers
-<gmv-autocomplete class="introInput">
-  <template v-slot:default="slotProps">
-    <v-text-field
-      outlined
-      prepend-inner-icon="place"
-      placeholder="Location Of Event"
-      ref="input"
-      v-bind:attrs="slotProps.attrs"
-    >
-    </v-text-field>
-  </template>
-</gmv-autocomplete>
-<gmv-autocomplete class="introInput" slot-ref-name="input2">
-  <template v-slot:default="slotProps">
-    <v-text-field
-      outlined
-      prepend-inner-icon="place"
-      placeholder="Location Of Event"
-      ref="input2"
-      v-bind:attrs="slotProps.attrs"
-    >
-    </v-text-field>
-  </template>
-</gmv-autocomplete>
-```
-
-If the element in the slot is a vue component then it must have a child ref called input (like in vuetify text-field) or specify a custom name via the child-ref-name prop (only works one level deep into a component).
-
-The v-bind:attrs is required.
+Request only the Place fields your screen needs. Broad field lists can increase Places data usage and billing. `set-fields-to` calls `autocomplete.setFields()` after the Google instance is created.
 :::
+
+## Restrict predictions
+
+Pass the same option names used by the Google Maps Autocomplete widget.
+
+```vue showLineNumbers
+<template>
+  <GmvAutocomplete
+    placeholder="Search in Chile"
+    :component-restrictions="{ country: 'cl' }"
+    :types="['geocode']"
+    :set-fields-to="['place_id', 'formatted_address', 'geometry']"
+    @place_changed="handlePlaceChanged"
+  />
+</template>
+```
+
+Useful props include:
+
+- `componentRestrictions`, restrict predictions to one or more countries.
+- `types`, restrict prediction types.
+- `bounds` and `strictBounds`, bias or restrict predictions by map bounds.
+- `fields`, pass requested fields to the constructor.
+- `setFieldsTo`, call `autocomplete.setFields()` after creation.
+
+## Custom input
+
+By default, `GmvAutocomplete` renders an `<input>` and forwards attributes such as `placeholder`, `class`, and `aria-label`. Prefer the default input unless you have tested a custom input in your app.
+
+```vue title="DefaultAutocompleteInput.vue" showLineNumbers
+<script setup lang="ts">
+function handlePlaceChanged(place: google.maps.places.PlaceResult) {
+  console.log(place);
+}
+</script>
+
+<template>
+  <GmvAutocomplete
+    class="search-input"
+    placeholder="Search for a place"
+    aria-label="Search for a place"
+    :set-fields-to="['place_id', 'name', 'geometry']"
+    @place_changed="handlePlaceChanged"
+  />
+</template>
+```
+
+:::warning
+Custom slots are advanced. The component needs a real `HTMLInputElement` through `slotRef` by the time `GmvAutocomplete` mounts. A normal parent template ref can be populated too late for this component's current mount flow. If you need a wrapped design-system input, verify it in your app before relying on it in production.
+:::
+
+## Access the Autocomplete instance
+
+Use a component ref when the parent needs the Google `Autocomplete` instance.
+
+```vue title="AutocompleteInstanceExample.vue" showLineNumbers
+<script setup lang="ts">
+import { Autocomplete } from "@gmap-vue/v3/components";
+import { ref } from "vue";
+
+const autocompleteRef = ref<InstanceType<typeof Autocomplete> | null>(null);
+
+async function logAutocompleteBounds() {
+  const autocomplete = await autocompleteRef.value?.autocompletePromise;
+  console.log(autocomplete?.getBounds());
+}
+</script>
+
+<template>
+  <GmvAutocomplete ref="autocompleteRef" placeholder="Search" />
+  <button @click="logAutocompleteBounds">Log bounds</button>
+</template>
+```
+
+For descendants or shared promise access, use `autocompleteKey` with `useAutocompletePromise(key)`.
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { useAutocompletePromise } from "@gmap-vue/v3/composables";
+
+const autocompleteKey = "header-search";
+const autocompletePromise = useAutocompletePromise(autocompleteKey);
+</script>
+
+<template>
+  <GmvAutocomplete :autocomplete-key="autocompleteKey" placeholder="Search" />
+</template>
+```
+
+## Gotchas
+
+- `GmvAutocomplete` does not implement `v-model` or emit `update:modelValue`.
+- `place_changed` emits the result of `autocomplete.getPlace()`, not a DOM event.
+- `selectFirstOnEnter` defaults to `true` and simulates selecting the first prediction when Enter is pressed.
+- Use unique `autocompleteKey` values when coordinating promise access for multiple autocomplete instances.
+
+## Related pages
+
+- [Generated component API](/docs/vue-3-version/api/components/autocomplete)
+- [Composables API](/docs/vue-3-version/api/composables)
+- [Google Places Autocomplete guide](https://developers.google.com/maps/documentation/javascript/place-autocomplete)


### PR DESCRIPTION
## Summary

- rewrite the Vue 3 `GmvAutocomplete` guide around setup, `places` library requirements, `place_changed`, field selection, restrictions, instance access, and gotchas
- align the Autocomplete API page with the actual component props, event payload, slot behavior, and exposed `autocompletePromise`
- document `useAutocompletePromise` in the composables API

## Validation

- pnpm run --filter docs typecheck
- pnpm run --filter docs build

## Review notes

A fresh reviewer flagged the first custom-slot example as unsafe because `slotRef` can be populated too late for the component mount flow. The final docs prefer the default input and warn that custom slots are advanced and must be verified.

`research.md` remains untracked and is not part of this PR.
