### PR TITLE
docs(docs): add vue 3 marker info window guides

### DIFF
--- a/packages/documentation/docs/vue-3-version/api/components/index.md
+++ b/packages/documentation/docs/vue-3-version/api/components/index.md
@@ -30,10 +30,10 @@ import {
 
 | Export | Global plugin name | Purpose |
 | --- | --- | --- |
-| `MapLayer` | `GmvMap` | Base Google Map component. |
-| `Marker` | `GmvMarker` | Marker or advanced marker on the map. |
-| `InfoWindow` | `GmvInfoWindow` | Info window anchored to a marker or position. |
-| `Autocomplete` | `GmvAutocomplete` | Places autocomplete input wrapper. |
+| [`MapLayer`](./map.md) | `GmvMap` | Base Google Map component. |
+| [`Marker`](./marker.md) | `GmvMarker` | Advanced Marker on the map. |
+| [`InfoWindow`](./info-window.md) | `GmvInfoWindow` | Info window anchored to a marker or position. |
+| [`Autocomplete`](./autocomplete.md) | `GmvAutocomplete` | Places autocomplete input wrapper. |
 | `Circle` | `GmvCircle` | Circle overlay. |
 | `Polygon` | `GmvPolygon` | Polygon overlay. |
 | `Polyline` | `GmvPolyline` | Polyline overlay. |

--- a/packages/documentation/docs/vue-3-version/api/components/info-window.md
+++ b/packages/documentation/docs/vue-3-version/api/components/info-window.md
@@ -1,0 +1,146 @@
+---
+id: info-window
+sidebar_position: 4
+sidebar_label: InfoWindow
+---
+
+# InfoWindow
+
+:::info Official sources
+
+- [InfoWindow guide](https://developers.google.com/maps/documentation/javascript/infowindows)
+- [InfoWindow reference](https://developers.google.com/maps/documentation/javascript/reference/info-window)
+
+:::
+
+`GmvInfoWindow` wraps `google.maps.InfoWindow`. It uses `google.maps.importLibrary("maps")`, creates a Google InfoWindow, and opens it on a map, on a marker, or at a position.
+
+The component is exported as `InfoWindow` from `@gmap-vue/v3/components` and registered by the plugin as `GmvInfoWindow`.
+
+## Props
+
+```ts title="InfoWindow props interface" showLineNumbers
+export interface InfoWindowProps {
+  ariaLabel?: string;
+  content?: string | Element | Text;
+  disableAutoPan?: boolean;
+  maxWidth?: number;
+  minWidth?: number;
+  pixelOffset?: google.maps.Size;
+  position?: google.maps.LatLng | google.maps.LatLngLiteral;
+  zIndex?: number;
+  opened?: boolean;
+  marker?: google.maps.marker.AdvancedMarkerElement;
+  infoWindowKey?: string;
+  markerKey?: string;
+  mapKey?: string;
+  options?: Record<string | number | symbol, unknown>;
+}
+```
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `ariaLabel` | `string` | `undefined` | Accessibility label for the info window. |
+| `content` | `string \| Element \| Text` | `undefined` | Content applied through the component watcher when this prop changes. For initial rendered content, prefer the default slot. |
+| `disableAutoPan` | `boolean` | `false` | Prevents the map from panning to show the info window. |
+| `maxWidth` | `number` | `undefined` | Maximum width in pixels. |
+| `minWidth` | `number` | `undefined` | Minimum width in pixels. |
+| `pixelOffset` | `google.maps.Size` | `undefined` | Pixel offset from the anchor. |
+| `position` | `google.maps.LatLng \| google.maps.LatLngLiteral` | `undefined` | Position for map-only info windows. |
+| `zIndex` | `number` | `undefined` | Stacking order. |
+| `opened` | `boolean` | `undefined` | Controls whether the info window is open. |
+| `marker` | `google.maps.marker.AdvancedMarkerElement` | `undefined` | Explicit marker anchor. Used when no marker is resolved from `markerKey`. |
+| `infoWindowKey` | `string` | `undefined` | Promise key used by `useInfoWindowPromise(key)`. |
+| `markerKey` | `string` | `undefined` | Marker promise key used to anchor the info window. |
+| `mapKey` | `string` | `undefined` | Map promise key used when the info window is not a direct descendant of `GmvMap`. |
+| `options` | `Record<string \| number \| symbol, unknown>` | `undefined` | Fallback for Google InfoWindow options not yet represented by explicit props. |
+
+## Open behavior
+
+When `opened` is truthy, `GmvInfoWindow` opens with this precedence:
+
+1. marker resolved from `markerKey`,
+2. explicit `marker` prop,
+3. map-only open.
+
+When `opened` is falsey, it calls `infoWindow.close()`.
+
+Changing `position` while open calls `setPosition(value)` and reopens the info window. Changing `marker` while open reopens it anchored to the new marker.
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `close` | none | Fired when the info window closes. |
+| `closeclick` | none | Fired when the close button is clicked. |
+| `content_changed` | none | Fired when Google reports content changed. |
+| `domready` | none | Fired when the content DOM is attached. |
+| `position_changed` | none | Fired when Google reports position changed. |
+| `visible` | none | Fired when the info window becomes visible. |
+| `zindex_changed` | none | Fired when Google reports z-index changed. |
+
+## Slots
+
+The default slot is used as info window content.
+
+```vue showLineNumbers
+<template>
+  <GmvMap
+    :center="{ lat: -34.6037, lng: -58.3816 }"
+    :zoom="13"
+    style="width: 100%; height: 500px"
+  >
+    <GmvInfoWindow :position="{ lat: -34.6037, lng: -58.3816 }" :opened="true">
+      <strong>Details</strong>
+    </GmvInfoWindow>
+  </GmvMap>
+</template>
+```
+
+:::warning
+Slot content is moved into Google Maps' DOM on mount so the Google InfoWindow can own the rendered content. Avoid relying on the original parent DOM structure around slotted content.
+:::
+
+## Exposed properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `infoWindowPromise` | `Promise<google.maps.InfoWindow \| undefined>` | Resolves to the underlying Google InfoWindow instance. |
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { InfoWindow } from "@gmap-vue/v3/components";
+import { ref } from "vue";
+
+const infoWindowRef = ref<InstanceType<typeof InfoWindow> | null>(null);
+
+async function readInfoWindow() {
+  const infoWindow = await infoWindowRef.value?.infoWindowPromise;
+  console.log(infoWindow?.getPosition());
+}
+</script>
+
+<template>
+  <GmvMap
+    :center="{ lat: -34.6037, lng: -58.3816 }"
+    :zoom="13"
+    style="width: 100%; height: 500px"
+  >
+    <GmvInfoWindow
+      ref="infoWindowRef"
+      :position="{ lat: -34.6037, lng: -58.3816 }"
+      :opened="true"
+    >
+      Details
+    </GmvInfoWindow>
+  </GmvMap>
+
+  <button @click="readInfoWindow">Read info window</button>
+</template>
+```
+
+## Related APIs
+
+- [`useInfoWindowPromise`](/docs/vue-3-version/api/composables#useinfowindowpromise)
+- [InfoWindow guide](/docs/vue-3-version/guide/components/info-window)
+- [Marker guide](/docs/vue-3-version/guide/components/marker)

--- a/packages/documentation/docs/vue-3-version/api/components/marker.md
+++ b/packages/documentation/docs/vue-3-version/api/components/marker.md
@@ -1,0 +1,114 @@
+---
+id: marker
+sidebar_position: 3
+sidebar_label: Marker
+---
+
+# Marker
+
+:::info Official sources
+
+- [Advanced Marker guide](https://developers.google.com/maps/documentation/javascript/advanced-markers/overview)
+- [AdvancedMarkerElement reference](https://developers.google.com/maps/documentation/javascript/reference/advanced-markers#AdvancedMarkerElement)
+
+:::
+
+`GmvMarker` wraps `google.maps.marker.AdvancedMarkerElement`. It uses `google.maps.importLibrary("marker")`, so document and configure it as an Advanced Marker, not as legacy `google.maps.Marker`.
+
+The component is exported as `Marker` from `@gmap-vue/v3/components` and registered by the plugin as `GmvMarker`.
+
+## Props
+
+```ts title="Marker props interface" showLineNumbers
+export interface MarkerProps {
+  collisionBehavior?: google.maps.CollisionBehavior;
+  content?: HTMLElement;
+  gmpClickable?: boolean;
+  gmpDraggable?: boolean;
+  position?:
+    | google.maps.LatLng
+    | google.maps.LatLngLiteral
+    | google.maps.LatLngAltitude
+    | google.maps.LatLngAltitudeLiteral;
+  title?: string;
+  zIndex?: number;
+  markerKey?: string;
+  clusterKey?: string;
+  mapKey?: string;
+  options?: Record<string, unknown>;
+}
+```
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `collisionBehavior` | `google.maps.CollisionBehavior` | `undefined` | Advanced Marker collision behavior. |
+| `content` | `HTMLElement` | `undefined` | DOM content passed to the Advanced Marker options. Verify mount timing when passing Vue-owned elements. |
+| `gmpClickable` | `boolean` | `true` | Enables Advanced Marker click behavior. This is part of the Google Advanced Marker beta surface. |
+| `gmpDraggable` | `boolean` | `false` | Enables marker dragging. |
+| `position` | `google.maps.LatLng \| google.maps.LatLngLiteral \| google.maps.LatLngAltitude \| google.maps.LatLngAltitudeLiteral` | `undefined` | Marker position. |
+| `title` | `string` | `undefined` | Accessibility text and hover title. |
+| `zIndex` | `number` | `undefined` | Marker stacking order. |
+| `markerKey` | `string` | `undefined` | Promise key used by `useMarkerPromise(key)`. |
+| `clusterKey` | `string` | `undefined` | Cluster promise key used when adding the marker to a specific cluster. |
+| `mapKey` | `string` | `undefined` | Map promise key used when the marker is not a direct descendant of `GmvMap`. |
+| `options` | `Record<string, unknown>` | `undefined` | Fallback for Google Advanced Marker options not yet represented by explicit props. |
+
+## Map and cluster resolution
+
+When `mapKey` is provided, the component injects that map promise. Without `mapKey`, it finds the parent `GmvMap` instance.
+
+When `clusterKey` is provided, the component uses that cluster promise. Without `clusterKey`, it can find a parent `GmvCluster`. Clustered markers are created without a map and are added to the clusterer.
+
+## Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `click` | `google.maps.MapMouseEvent` | Standard marker click event. |
+| `drag` | `google.maps.MapMouseEvent` | Fired while dragging. |
+| `dragstart` | `google.maps.MapMouseEvent` | Fired when dragging starts. |
+| `dragend` | `google.maps.MapMouseEvent` | Fired when dragging ends. |
+| `gmp-click` | `google.maps.marker.AdvancedMarkerClickEvent` | Advanced Marker click event. |
+| `update:position` | `{ lat?: number; lng?: number }` | Fired after `dragend` with the marker's current position. |
+
+## Exposed properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `markerPromise` | `Promise<google.maps.marker.AdvancedMarkerElement \| undefined>` | Resolves to the underlying Advanced Marker instance. |
+| `VNodeMarkerIcon` | `VNode \| undefined` | Internal vnode used when marker content participates in parent-child component behavior. |
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { Marker } from "@gmap-vue/v3/components";
+import { ref } from "vue";
+
+const markerRef = ref<InstanceType<typeof Marker> | null>(null);
+
+async function readMarker() {
+  const marker = await markerRef.value?.markerPromise;
+  console.log(marker?.position);
+}
+</script>
+
+<template>
+  <GmvMap
+    :center="{ lat: -34.6037, lng: -58.3816 }"
+    :zoom="13"
+    style="width: 100%; height: 500px"
+  >
+    <GmvMarker
+      ref="markerRef"
+      :position="{ lat: -34.6037, lng: -58.3816 }"
+      title="Marker"
+    />
+  </GmvMap>
+
+  <button @click="readMarker">Read marker</button>
+</template>
+```
+
+## Related APIs
+
+- [`useMarkerPromise`](/docs/vue-3-version/api/composables#usemarkerpromise)
+- [Marker guide](/docs/vue-3-version/guide/components/marker)
+- [InfoWindow guide](/docs/vue-3-version/guide/components/info-window)

--- a/packages/documentation/docs/vue-3-version/guide/components/info-window.md
+++ b/packages/documentation/docs/vue-3-version/guide/components/info-window.md
@@ -1,0 +1,139 @@
+---
+id: info-window
+sidebar_position: 4
+sidebar_label: InfoWindow
+---
+
+# InfoWindow
+
+`GmvInfoWindow` renders a Google Maps `InfoWindow` on a `GmvMap`. Use it for contextual content anchored to a marker or to a map position.
+
+The component is exported as `InfoWindow` from `@gmap-vue/v3/components` and registered by the plugin as `GmvInfoWindow`.
+
+## Basic controlled info window
+
+Control visibility with the `opened` prop. A marker click can update normal Vue state and open the info window.
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { ref } from "vue";
+
+const center = { lat: -34.6037, lng: -58.3816 };
+const infoOpen = ref(false);
+</script>
+
+<template>
+  <GmvMap :center="center" :zoom="13" style="width: 100%; height: 500px">
+    <GmvMarker
+      marker-key="main-marker"
+      :position="center"
+      title="Buenos Aires"
+      @click="infoOpen = true"
+      @gmp-click="infoOpen = true"
+    />
+
+    <GmvInfoWindow
+      marker-key="main-marker"
+      :opened="infoOpen"
+      aria-label="Buenos Aires details"
+      @closeclick="infoOpen = false"
+      @close="infoOpen = false"
+    >
+      <strong>Buenos Aires</strong>
+      <p>Selected marker details.</p>
+    </GmvInfoWindow>
+  </GmvMap>
+</template>
+```
+
+`opened` is controlled by your component state. Closing the Google UI does not mutate your state automatically, so handle `close` or `closeclick` when you want the Vue state to follow the Google state.
+
+## Anchor to a marker
+
+The most common pattern is to use the same `marker-key` on `GmvMarker` and `GmvInfoWindow`. When opened, `GmvInfoWindow` prefers the marker resolved from `marker-key`, then the explicit `marker` prop, then a map-only open.
+
+```vue showLineNumbers
+<template>
+  <GmvMap :center="center" :zoom="13" style="width: 100%; height: 500px">
+    <GmvMarker marker-key="store-marker" :position="center" title="Store" />
+
+    <GmvInfoWindow marker-key="store-marker" :opened="true">
+      Store location
+    </GmvInfoWindow>
+  </GmvMap>
+</template>
+```
+
+If you already have a `google.maps.marker.AdvancedMarkerElement`, pass it through the `marker` prop instead.
+
+## Position-only info window
+
+You can open an info window at a position without anchoring it to a marker.
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { ref } from "vue";
+
+const position = ref({ lat: -34.6037, lng: -58.3816 });
+</script>
+
+<template>
+  <GmvMap :center="position" :zoom="13" style="width: 100%; height: 500px">
+    <GmvInfoWindow :position="position" :opened="true">
+      Info window at a map position
+    </GmvInfoWindow>
+  </GmvMap>
+</template>
+```
+
+When `opened` is true and `position` changes, the component calls `setPosition()` and reopens the info window.
+
+## Access the info window instance
+
+Use `info-window-key` with `useInfoWindowPromise` when you need direct access to the Google `InfoWindow` instance.
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { useInfoWindowPromise } from "@gmap-vue/v3/composables";
+
+const center = { lat: -34.6037, lng: -58.3816 };
+const infoWindowKey = "details-window";
+const infoWindowPromise = useInfoWindowPromise(infoWindowKey);
+
+async function closeFromCode() {
+  const infoWindow = await infoWindowPromise;
+  infoWindow?.close();
+}
+</script>
+
+<template>
+  <GmvMap :center="center" :zoom="13" style="width: 100%; height: 500px">
+    <GmvInfoWindow
+      :info-window-key="infoWindowKey"
+      :position="center"
+      :opened="true"
+    >
+      Details
+    </GmvInfoWindow>
+  </GmvMap>
+
+  <button @click="closeFromCode">Close Google instance</button>
+</template>
+```
+
+Prefer the `opened` prop for normal app state. Direct instance access is best for methods not exposed as Vue props yet.
+
+## Gotchas
+
+- `opened` controls open and close; keep your Vue state in sync with `close` or `closeclick` if the user can close the window from the Google UI.
+- Slot content is moved into Google Maps' DOM when the component mounts. Avoid relying on parent DOM structure around slotted content.
+- Changing `position` while open updates the position and reopens the info window.
+- Changing `marker` while open reopens the info window anchored to the new marker.
+- Use `map-key` when the info window cannot discover a parent `GmvMap`.
+
+## Related pages
+
+- [InfoWindow API](/docs/vue-3-version/api/components/info-window)
+- [Marker guide](/docs/vue-3-version/guide/components/marker)
+- [Map guide](/docs/vue-3-version/guide/components/map)
+- [Google InfoWindow reference](https://developers.google.com/maps/documentation/javascript/reference/info-window)

--- a/packages/documentation/docs/vue-3-version/guide/components/marker.md
+++ b/packages/documentation/docs/vue-3-version/guide/components/marker.md
@@ -1,0 +1,151 @@
+---
+id: marker
+sidebar_position: 3
+sidebar_label: Marker
+---
+
+# Marker
+
+`GmvMarker` renders a Google Maps [Advanced Marker](https://developers.google.com/maps/documentation/javascript/advanced-markers/overview) on a `GmvMap`.
+
+The component is exported as `Marker` from `@gmap-vue/v3/components` and registered by the plugin as `GmvMarker`.
+
+## Basic usage
+
+Place `GmvMarker` inside a `GmvMap`. The marker finds the parent map automatically.
+
+```vue showLineNumbers
+<script setup lang="ts">
+const center = { lat: -34.6037, lng: -58.3816 };
+</script>
+
+<template>
+  <GmvMap :center="center" :zoom="13" style="width: 100%; height: 500px">
+    <GmvMarker :position="center" title="Buenos Aires" />
+  </GmvMap>
+</template>
+```
+
+`GmvMarker` uses `google.maps.importLibrary("marker")` and creates a `google.maps.marker.AdvancedMarkerElement`. Do not use legacy `google.maps.Marker` options unless the component explicitly supports them.
+
+## React to marker clicks
+
+Use Vue events for normal UI state.
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { ref } from "vue";
+
+const selected = ref(false);
+const position = { lat: -34.6037, lng: -58.3816 };
+</script>
+
+<template>
+  <GmvMap :center="position" :zoom="13" style="width: 100%; height: 500px">
+    <GmvMarker
+      :position="position"
+      title="Open details"
+      @click="selected = true"
+      @gmp-click="selected = true"
+    />
+  </GmvMap>
+
+  <p v-if="selected">Marker selected.</p>
+</template>
+```
+
+`click` is the normal Maps event. `gmp-click` is the Advanced Marker event exposed by Google Maps for clickable advanced markers.
+
+## Draggable marker
+
+Set `gmp-draggable` and listen for `update:position`. The component emits `{ lat?: number; lng?: number }` after `dragend`.
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { ref } from "vue";
+
+const markerPosition = ref({ lat: -34.6037, lng: -58.3816 });
+
+function updateMarkerPosition(position: { lat?: number; lng?: number }) {
+  if (typeof position.lat === "number" && typeof position.lng === "number") {
+    markerPosition.value = { lat: position.lat, lng: position.lng };
+  }
+}
+</script>
+
+<template>
+  <GmvMap
+    :center="markerPosition"
+    :zoom="13"
+    style="width: 100%; height: 500px"
+  >
+    <GmvMarker
+      :position="markerPosition"
+      gmp-draggable
+      title="Drag me"
+      @update:position="updateMarkerPosition"
+    />
+  </GmvMap>
+
+  <pre>{{ markerPosition }}</pre>
+</template>
+```
+
+## Access the marker instance
+
+Prefer props and events first. Use `marker-key` and `useMarkerPromise` only when you need the underlying Google Advanced Marker instance.
+
+```vue showLineNumbers
+<script setup lang="ts">
+import { useMarkerPromise } from "@gmap-vue/v3/composables";
+
+const center = { lat: -34.6037, lng: -58.3816 };
+const markerKey = "office-marker";
+const markerPromise = useMarkerPromise(markerKey);
+
+async function logMarkerPosition() {
+  const marker = await markerPromise;
+  console.log(marker?.position);
+}
+</script>
+
+<template>
+  <GmvMap :center="center" :zoom="13" style="width: 100%; height: 500px">
+    <GmvMarker :marker-key="markerKey" :position="center" title="Office" />
+  </GmvMap>
+
+  <button @click="logMarkerPosition">Log marker position</button>
+</template>
+```
+
+When a marker is not a direct child of the map, pass `map-key` so it can use the correct map promise.
+
+## Marker content
+
+Advanced markers can use custom DOM content through the `content` prop, which maps to `AdvancedMarkerElementOptions.content`.
+
+The current component also accepts default slot content internally, but that slot is not assigned to the Google Advanced Marker `content` option. Do not rely on the default slot to render custom marker DOM until that behavior is explicitly supported by the component.
+
+For most cases, start with the default Google pin plus `title`, `position`, and drag/click events. If you need custom DOM marker content, pass an `HTMLElement` through `content` and verify the mount timing in your app.
+
+## Clustering note
+
+`GmvMarker` can join a `GmvCluster` through a parent cluster component or a matching `cluster-key`. When clustered, the marker is created without a map and added to the clusterer.
+
+Full clustering examples will live in dedicated cluster documentation. For now, use a stable `marker-key` for markers you need to access individually.
+
+## Gotchas
+
+- `GmvMarker` wraps `google.maps.marker.AdvancedMarkerElement`, not legacy `google.maps.Marker`.
+- `gmpClickable` defaults to `true` and `gmpDraggable` defaults to `false`.
+- `gmpClickable` is part of the Advanced Marker beta surface in Google Maps.
+- `update:position` is emitted after `dragend`, not continuously while dragging.
+- Use `map-key` when the marker cannot discover a parent `GmvMap`.
+- Use `cluster-key` when the marker must join a specific cluster promise.
+
+## Related pages
+
+- [Marker API](/docs/vue-3-version/api/components/marker)
+- [InfoWindow guide](/docs/vue-3-version/guide/components/info-window)
+- [Map guide](/docs/vue-3-version/guide/components/map)
+- [Google Advanced Markers](https://developers.google.com/maps/documentation/javascript/advanced-markers/overview)

--- a/packages/documentation/docs/vue-3-version/guide/components/other-components.md
+++ b/packages/documentation/docs/vue-3-version/guide/components/other-components.md
@@ -6,14 +6,15 @@ sidebar_label: Other components
 
 # Other Vue 3 components
 
-Start with `GmvMap`, then add only the Google Maps features your screen needs. This page gives you the practical role of each component before you jump into API details.
+Start with `GmvMap`, then add only the Google Maps features your screen needs. This page gives you the practical role of each component before you jump into dedicated guides or API details.
 
 ## Component overview
 
-| Component | Use it when | Notes |
+| Component | Use it when | Next step |
 | --- | --- | --- |
-| `GmvMarker` | You need a point on the map that can react to clicks or show an info window. | Use a stable `marker-key` when you need access through `useMarkerPromise`. |
-| `GmvInfoWindow` | You need contextual content anchored to a marker or position. | Updating `position` or `marker` while open is supported in `@gmap-vue/v3@2.2.1` and newer. |
+| `GmvMarker` | You need an Advanced Marker point on the map that can react to clicks, drag, join clusters, or anchor an info window. | Read the [Marker guide](./marker.md). |
+| `GmvInfoWindow` | You need contextual content anchored to a marker or position. | Read the [InfoWindow guide](./info-window.md). |
+| `GmvAutocomplete` | You need a Places-powered search input. | Read the [Autocomplete guide](./autocomplete.md). |
 | `GmvCircle` | You need a radius around a point. | Useful for coverage, distance, or search areas. |
 | `GmvPolygon` | You need a filled area with one or more paths. | Use for regions, zones, or custom boundaries. |
 | `GmvPolyline` | You need a path without a filled area. | Use for routes, tracks, or measured lines. |
@@ -32,7 +33,7 @@ Some components require optional Google Maps libraries. Add them to the plugin `
 createGmapVuePlugin({
   load: {
     key: import.meta.env.VITE_GOOGLE_MAPS_API_KEY,
-    libraries: 'places,visualization',
+    libraries: "places,visualization",
   },
 });
 ```
@@ -43,22 +44,43 @@ createGmapVuePlugin({
 | `GmvHeatmapLayer` | `visualization` |
 | `GmvDrawingManager` | `drawing`, only for environments where the removed Drawing Library is still available |
 
+`GmvMarker` and `GmvInfoWindow` import their Google Maps libraries internally with `google.maps.importLibrary("marker")` and `google.maps.importLibrary("maps")`.
+
 ## Access component instances
 
 Use composables when you need the underlying Google Maps object after a component is mounted.
 
-```vue title="MarkerExample.vue"
+```vue title="MarkerExample.vue" showLineNumbers
 <script setup lang="ts">
-import { useMarkerPromise } from '@gmap-vue/v3/composables';
+import { useMapPromise, useMarkerPromise } from "@gmap-vue/v3/composables";
+
+const mapKey = "main-map";
+const markerKey = "office-marker";
+const mapPromise = useMapPromise(mapKey);
+const markerPromise = useMarkerPromise(markerKey);
 
 async function focusMarker() {
-  const marker = await useMarkerPromise('office-marker');
-  marker?.map?.panTo(marker.position!);
+  const [map, marker] = await Promise.all([mapPromise, markerPromise]);
+  if (!map || !marker?.position) return;
+
+  map.panTo(marker.position);
 }
 </script>
 
 <template>
-  <GmvMarker marker-key="office-marker" :position="{ lat: 47.3763, lng: 8.5475 }" />
+  <GmvMap
+    :map-key="mapKey"
+    :center="{ lat: 47.3763, lng: 8.5475 }"
+    :zoom="13"
+    style="width: 100%; height: 500px"
+  >
+    <GmvMarker
+      :marker-key="markerKey"
+      :position="{ lat: 47.3763, lng: 8.5475 }"
+      title="Office"
+    />
+  </GmvMap>
+
   <button @click="focusMarker">Focus marker</button>
 </template>
 ```
@@ -68,5 +90,7 @@ Prefer component props and events for normal Vue state updates. Reach for `use*P
 ## Next steps
 
 - Use the [map guide](./map.md) for the base map setup.
+- Use the [Marker guide](./marker.md) when you need points, draggable markers, or direct marker access.
+- Use the [InfoWindow guide](./info-window.md) when you need contextual content anchored to a marker or position.
 - Use the [map reference guide](../basic-usage/map-reference.md) when you need direct map instance access.
 - Use the [API reference](/docs/vue-3-version/api/components) when you need supported component exports.

--- a/packages/documentation/sidebars.ts
+++ b/packages/documentation/sidebars.ts
@@ -22,6 +22,8 @@ const sidebars: SidebarsConfig = {
 			items: [
 				"vue-3-version/guide/components/map",
 				"vue-3-version/guide/basic-usage/map-reference",
+				"vue-3-version/guide/components/marker",
+				"vue-3-version/guide/components/info-window",
 				"vue-3-version/guide/components/autocomplete",
 				"vue-3-version/guide/components/other-components",
 			],
@@ -35,6 +37,8 @@ const sidebars: SidebarsConfig = {
 				"vue-3-version/api/gmap-vue-plugin",
 				"vue-3-version/api/components/introduction",
 				"vue-3-version/api/components/map",
+				"vue-3-version/api/components/marker",
+				"vue-3-version/api/components/info-window",
 				"vue-3-version/api/components/autocomplete",
 				"vue-3-version/api/composables",
 				"vue-3-version/api/utilities",


### PR DESCRIPTION
## Summary

- add Vue 3 user guides for `GmvMarker` and `GmvInfoWindow`
- add API reference pages for Marker and InfoWindow
- link the new pages from the Vue 3 guide/API sidebars and overview pages
- document Advanced Marker behavior, marker/info-window promise access, controlled `opened` state, marker anchoring, and runtime gotchas

## Validation

- pnpm run --filter docs typecheck
- pnpm run --filter docs build
- pnpm run lint

## Review notes

Fresh review initially flagged two inaccuracies: marker default slot content was not actually wired into Advanced Marker `content`, and InfoWindow `content` wording overpromised initial constructor behavior. Both were corrected, and a second fresh review returned go/no-go: Go, no blockers.

`research.md` remains untracked and is not part of this PR.
