### PR TITLE
docs(docs): add new gmap-vue logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # GmapVue
 
+<p align="center">
+  <img src="packages/documentation/static/img/logo.svg" alt="gmap-vue logo" width="260" />
+</p>
+
 [![Publish](https://github.com/diegoazh/gmap-vue/workflows/publish/badge.svg)](https://github.com/diegoazh/gmap-vue/actions?query=workflow%3Apublish)
 [![Documentation](https://github.com/diegoazh/gmap-vue/workflows/documentation/badge.svg)](https://github.com/diegoazh/gmap-vue/actions?query=workflow%3Adocumentation)
 

--- a/packages/documentation/docusaurus.config.ts
+++ b/packages/documentation/docusaurus.config.ts
@@ -6,7 +6,7 @@ import { GITHUB_URI, PROJECT_NAME } from "./constants";
 const config: Config = {
 	title: "GmapVue Docs",
 	tagline: "Google Maps components and composables for Vue",
-	favicon: "img/favicon.ico",
+	favicon: "img/favicon.svg",
 
 	// Set the production url of your site here
 	url: "https://diegoazh.github.io/",

--- a/packages/documentation/src/pages/index.module.css
+++ b/packages/documentation/src/pages/index.module.css
@@ -10,6 +10,12 @@
 	overflow: hidden;
 }
 
+.heroLogo {
+	width: min(260px, 72vw);
+	height: auto;
+	margin-bottom: 1.5rem;
+}
+
 @media screen and (max-width: 996px) {
 	.heroBanner {
 		padding: 2rem;

--- a/packages/documentation/src/pages/index.tsx
+++ b/packages/documentation/src/pages/index.tsx
@@ -1,15 +1,19 @@
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 import Layout from "@theme/Layout";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import HomepageFeatures from "@site/src/components/HomepageFeatures";
 import Heading from "@theme/Heading";
 
 import styles from "./index.module.css";
 
 function HomepageHeader() {
+	const logoUrl = useBaseUrl("img/logo.svg");
+
 	return (
 		<header className={clsx("hero hero--primary", styles.heroBanner)}>
 			<div className="container">
+				<img className={styles.heroLogo} src={logoUrl} alt="gmap-vue logo" />
 				<Heading as="h1" className="hero__title">
 					Google Maps components for Vue
 				</Heading>

--- a/packages/documentation/static/img/favicon.svg
+++ b/packages/documentation/static/img/favicon.svg
@@ -1,14 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 420" width="100%" height="100%" role="img" aria-labelledby="gmap-vue-logo-title gmap-vue-logo-description">
-  <title id="gmap-vue-logo-title">gmap-vue logo</title>
-  <desc id="gmap-vue-logo-description">A split blue and green map pin with code braces and the gmap-vue wordmark.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="60 85 280 210" role="img" aria-labelledby="gmap-vue-favicon-title">
+  <title id="gmap-vue-favicon-title">gmap-vue</title>
   <path d="M 200 100 C 166.863 100, 140 126.863, 140 160 C 140 210, 200 280, 200 280 L 200 100 Z" fill="#1D6BB2" />
   <path d="M 200 100 C 233.137 100, 260 126.863, 260 160 C 260 210, 200 280, 200 280 L 200 100 Z" fill="#6AB04C" />
   <circle cx="200" cy="160" r="25" fill="#FFFFFF" />
   <text x="200" y="161" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="30" font-weight="bold" fill="#1D6BB2" text-anchor="middle" dominant-baseline="central">V</text>
   <path d="M 110,120 C 95,120 90,130 90,145 L 90,175 C 90,185 82,190 75,190 C 82,190 90,195 90,205 L 90,235 C 90,250 95,260 110,260" fill="none" stroke="#F78822" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
   <path d="M 290,120 C 305,120 310,130 310,145 L 310,175 C 310,185 318,190 325,190 C 318,190 310,195 310,205 L 310,235 C 310,250 305,260 290,260" fill="none" stroke="#F78822" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
-  <text x="200" y="345" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="42" font-weight="bold" text-anchor="middle">
-    <tspan fill="#1D6BB2">gmap</tspan><tspan fill="#6AB04C">-vue</tspan>
-  </text>
-  <text x="200" y="385" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="16" font-weight="600" fill="#555555" text-anchor="middle" letter-spacing="1">Vue 3 Google Maps</text>
 </svg>


### PR DESCRIPTION
## Summary

- replace the documentation logo with the new gmap-vue SVG
- add a favicon SVG for GitHub Pages
- show the logo in the root README and documentation homepage
- switch Docusaurus favicon config to the new SVG asset

## Validation

- pnpm run --filter docs typecheck
- pnpm run --filter docs build

## Review notes

Fresh review found one blocker: the new favicon SVG had to be included in the commit because Docusaurus references it. The PR stages that asset explicitly. I also applied the optional suggestion to resolve the homepage image through Docusaurus `useBaseUrl`.

`research.md` remains untracked and is not part of this PR.
