### PR TITLE
docs(docs): polish vue 3 docs navigation

### DIFF
--- a/packages/documentation/docs/vue-3-version/api/04-composables.md
+++ b/packages/documentation/docs/vue-3-version/api/04-composables.md
@@ -197,7 +197,7 @@ You can use it to be sure that the `GmvMap` component is ready.
  * @public
  */
 export function useMapPromise(
-  key: string | InjectionKey<Promise<google.maps.Map | undefined>>,
+  key: string | InjectionKey<Promise<google.maps.Map | undefined>> = $mapPromise,
 ): Promise<google.maps.Map | undefined> {
   return usePromise<google.maps.Map>(key);
 }
@@ -208,8 +208,11 @@ When the GmvMap component is initialized and the map is ready this promise is re
 ```ts title="map-layer.vue" showLineNumbers
 //...
 
-const mapPromiseDeferred = usePromiseDeferred(props.mapKey || $mapPromise);
-promiseDeferred.resolve(mapInstance);
+const { promiseDeferred: mapPromiseDeferred, promise } =
+  useComponentPromiseFactory(defineMapKey() || $mapPromise);
+provide(defineMapKey() || $mapPromise, promise);
+
+mapPromiseDeferred.resolve(mapInstance);
 
 // ...
 ```
@@ -317,7 +320,7 @@ export function useMarkerPromise(
     | string
     | InjectionKey<
         Promise<google.maps.marker.AdvancedMarkerElement | undefined>
-      >,
+      > = $markerPromise,
 ): Promise<google.maps.marker.AdvancedMarkerElement | undefined> {
   return usePromise<google.maps.marker.AdvancedMarkerElement>(key);
 }
@@ -453,7 +456,7 @@ This composable is similar to the previous above, the only difference is that it
  * @public
  */
 export function useInfoWindowPromise(
-  key: string | InjectionKey<Promise<google.maps.InfoWindow | undefined>>,
+  key: string | InjectionKey<Promise<google.maps.InfoWindow | undefined>> = $infoWindowPromise,
 ): Promise<google.maps.InfoWindow | undefined> {
   return usePromise<google.maps.InfoWindow>(key);
 }

--- a/packages/documentation/docs/vue-3-version/api/components/map.md
+++ b/packages/documentation/docs/vue-3-version/api/components/map.md
@@ -474,7 +474,7 @@ import {
 /**
  * Map component
  * @displayName GmvMap
- * @see [source code](/docs/vue-3-version/guide/components/map#source-code)
+ * @see [source code](https://github.com/diegoazh/gmap-vue/blob/master/packages/v3/src/components/map-layer.vue)
  * @see [Official documentation](https://developers.google.com/maps/documentation/javascript/basics)
  * @see [Official reference](https://developers.google.com/maps/documentation/javascript/reference/map)
  */

--- a/packages/documentation/docs/vue-3-version/guide/components/autocomplete.md
+++ b/packages/documentation/docs/vue-3-version/guide/components/autocomplete.md
@@ -12,7 +12,7 @@ The component is exported as `Autocomplete` from `@gmap-vue/v3/components` and r
 
 ## Enable the Places library
 
-`GmvAutocomplete` calls `google.maps.importLibrary("places")`. The plugin defaults `load.libraries` to `"places"`, but if you override libraries you must keep `places` included.
+`GmvAutocomplete` calls `google.maps.importLibrary("places")`. The plugin defaults `load.libraries` to `"places"`; keeping `places` in your loader config is still useful when you want to make the dependency explicit or preload the library.
 
 ```ts title="main.ts excerpt" showLineNumbers
 createGmapVuePlugin({
@@ -23,7 +23,7 @@ createGmapVuePlugin({
 });
 ```
 
-When combining libraries, use a comma-separated string:
+When preloading multiple libraries, use a comma-separated string:
 
 ```ts title="main.ts excerpt" showLineNumbers
 libraries: "places,visualization";

--- a/packages/documentation/docs/vue-3-version/guide/components/other-components.md
+++ b/packages/documentation/docs/vue-3-version/guide/components/other-components.md
@@ -25,9 +25,9 @@ Start with `GmvMap`, then add only the Google Maps features your screen needs. T
 | `GmvStreetViewPanorama` | You need an embedded standalone Street View panorama. | Read the [Street View Panorama guide](./street-view-panorama.md). |
 | `GmvDrawingManager` | You maintain an app that still depends on the old Drawing Library. | Read the [Drawing Manager legacy guide](./drawing-manager.md). |
 
-## Loading required Google Maps libraries
+## Optional Google Maps library preloading
 
-Some components use optional Google Maps libraries. Keep those libraries available in your loader configuration when your app depends on them.
+Some components use optional Google Maps libraries. The wrappers import those libraries internally, but you can still list them in your loader configuration when you want to make dependencies explicit or preload them.
 
 ```ts title="main.ts"
 createGmapVuePlugin({
@@ -42,7 +42,7 @@ createGmapVuePlugin({
 | --- | --- |
 | `GmvAutocomplete` | `places` |
 | `GmvHeatmapLayer` | `visualization` |
-| `GmvDrawingManager` | `drawing`, only for environments where the removed Drawing Library is still available |
+| `GmvDrawingManager` | `drawing`, only for legacy environments where Google still serves the removed Drawing Library |
 
 `GmvMarker` imports the Google Maps `marker` library internally. `GmvInfoWindow`, `GmvKmlLayer`, and the shape components (`GmvCircle`, `GmvPolygon`, `GmvPolyline`, and `GmvRectangle`) import the Google Maps `maps` library internally. `GmvHeatmapLayer` imports the Google Maps `visualization` library internally. `GmvStreetViewPanorama` imports the Google Maps `streetView` library internally. `GmvCluster` uses the package dependency `@googlemaps/markerclusterer`.
 

--- a/packages/documentation/sidebars.ts
+++ b/packages/documentation/sidebars.ts
@@ -10,9 +10,14 @@ const sidebars: SidebarsConfig = {
 			items: [
 				"vue-3-version/guide/introduction",
 				"vue-3-version/guide/install-function",
+				"vue-3-version/guide/global-properties",
 				"vue-3-version/guide/basic-usage/dynamic-load",
+				"vue-3-version/guide/basic-usage/lazy-loading",
 				"vue-3-version/guide/basic-usage/region-and-language",
 				"vue-3-version/guide/basic-usage/accessing-google-maps-api",
+				"vue-3-version/guide/basic-usage/nuxt",
+				"vue-3-version/guide/basic-usage/gmv-map-slots",
+				"vue-3-version/guide/basic-usage/plugin-component-builder",
 			],
 		},
 		{


### PR DESCRIPTION
## Summary

- surface existing Vue 3 guide pages in the sidebar
- align composable default-key snippets with current source
- replace a broken map source-code anchor with the GitHub source link
- clarify Google library wording for Autocomplete and component overview pages

## Validation

- pnpm run --filter docs typecheck
- pnpm run --filter docs build

## Review notes

Fresh review initially caught one mismatch in the `map-layer.vue` source excerpt. The snippet now matches the source `useComponentPromiseFactory(defineMapKey() || $mapPromise)` / `provide(...)` pattern, and follow-up fresh review returned GO.

`research.md` remains untracked and is not part of this PR.
