### PR TITLE
docs(docs): improve documentation homepage

### DIFF
--- a/packages/documentation/src/components/HomepageFeatures/index.tsx
+++ b/packages/documentation/src/components/HomepageFeatures/index.tsx
@@ -13,8 +13,9 @@ const FeatureList: FeatureItem[] = [
 		title: "Install once, use components",
 		description: (
 			<>
-				Register the Vue 3 plugin, import the stylesheet, and start with
-				`GmvMap`, `GmvMarker`, `GmvInfoWindow`, and other Google Maps wrappers.
+				Register the Vue 3 plugin, import the stylesheet, and start with{" "}
+				<code>GmvMap</code>, <code>GmvMarker</code>, <code>GmvInfoWindow</code>,
+				and other Google Maps wrappers.
 			</>
 		),
 	},
@@ -33,7 +34,7 @@ const FeatureList: FeatureItem[] = [
 		description: (
 			<>
 				Access map, marker, shape, layer, and autocomplete instances from Vue
-				code with key-based `use*Promise` composables.
+				code with key-based <code>use*Promise</code> composables.
 			</>
 		),
 	},
@@ -42,7 +43,7 @@ const FeatureList: FeatureItem[] = [
 function Feature({ title, description }: FeatureItem) {
 	return (
 		<div className={clsx("col col--4")}>
-			<div className="padding-horiz--md">
+			<div className={styles.featureCard}>
 				<Heading as="h3">{title}</Heading>
 				<p>{description}</p>
 			</div>

--- a/packages/documentation/src/components/HomepageFeatures/styles.module.css
+++ b/packages/documentation/src/components/HomepageFeatures/styles.module.css
@@ -27,3 +27,21 @@
 .featureCard code {
 	white-space: nowrap;
 }
+
+:global([data-theme="dark"]) .features {
+	background: #0b1120;
+}
+
+:global([data-theme="dark"]) .featureCard {
+	border-color: rgba(148, 163, 184, 0.18);
+	background: linear-gradient(180deg, #111827 0%, #0f172a 100%);
+	box-shadow: 0 12px 30px rgba(0, 0, 0, 0.28);
+}
+
+:global([data-theme="dark"]) .featureCard h3 {
+	color: #f8fafc;
+}
+
+:global([data-theme="dark"]) .featureCard p {
+	color: #cbd5e1;
+}

--- a/packages/documentation/src/components/HomepageFeatures/styles.module.css
+++ b/packages/documentation/src/components/HomepageFeatures/styles.module.css
@@ -1,6 +1,29 @@
 .features {
 	display: flex;
-	align-items: center;
-	padding: 3rem 0;
+	align-items: stretch;
+	padding: 3.5rem 0;
 	width: 100%;
+	background: #ffffff;
+}
+
+.featureCard {
+	height: 100%;
+	padding: 1.5rem;
+	border: 1px solid rgba(29, 107, 178, 0.12);
+	border-radius: 1rem;
+	background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+	box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+}
+
+.featureCard h3 {
+	color: #17324d;
+}
+
+.featureCard p {
+	margin-bottom: 0;
+	color: #334155;
+}
+
+.featureCard code {
+	white-space: nowrap;
 }

--- a/packages/documentation/src/pages/index.module.css
+++ b/packages/documentation/src/pages/index.module.css
@@ -1,24 +1,34 @@
-/**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
- */
-
 .heroBanner {
-	padding: 4rem 0;
+	padding: 5rem 0 4rem;
 	text-align: center;
 	position: relative;
 	overflow: hidden;
+	background:
+		radial-gradient(circle at 50% 0%, rgba(106, 176, 76, 0.16), transparent 34rem),
+		linear-gradient(135deg, #f8fbff 0%, #ffffff 48%, #f4faf2 100%);
+	color: #17324d;
+}
+
+.heroBanner :global(.hero__title) {
+	color: #17324d;
+	font-weight: 800;
+	letter-spacing: -0.03em;
+}
+
+.heroBanner :global(.hero__subtitle) {
+	color: #334155;
 }
 
 .heroLogo {
 	width: min(260px, 72vw);
 	height: auto;
 	margin-bottom: 1.5rem;
+	filter: drop-shadow(0 16px 28px rgba(29, 107, 178, 0.16));
 }
 
 @media screen and (max-width: 996px) {
 	.heroBanner {
-		padding: 2rem;
+		padding: 2.5rem 1rem;
 	}
 }
 
@@ -28,4 +38,28 @@
 	justify-content: center;
 	gap: 1rem;
 	flex-wrap: wrap;
+}
+
+.primaryButton {
+	border-color: #1d6bb2;
+	background: #1d6bb2;
+	color: #ffffff;
+}
+
+.primaryButton:hover {
+	border-color: #15548c;
+	background: #15548c;
+	color: #ffffff;
+}
+
+.secondaryButton {
+	border: 1px solid rgba(29, 107, 178, 0.35);
+	background: #ffffff;
+	color: #1d6bb2;
+}
+
+.secondaryButton:hover {
+	border-color: #6ab04c;
+	background: #f4faf2;
+	color: #17324d;
 }

--- a/packages/documentation/src/pages/index.module.css
+++ b/packages/documentation/src/pages/index.module.css
@@ -4,7 +4,11 @@
 	position: relative;
 	overflow: hidden;
 	background:
-		radial-gradient(circle at 50% 0%, rgba(106, 176, 76, 0.16), transparent 34rem),
+		radial-gradient(
+			circle at 50% 0%,
+			rgba(106, 176, 76, 0.16),
+			transparent 34rem
+		),
 		linear-gradient(135deg, #f8fbff 0%, #ffffff 48%, #f4faf2 100%);
 	color: #17324d;
 }
@@ -62,4 +66,51 @@
 	border-color: #6ab04c;
 	background: #f4faf2;
 	color: #17324d;
+}
+
+:global([data-theme="dark"]) .heroBanner {
+	background:
+		radial-gradient(
+			circle at 50% 0%,
+			rgba(106, 176, 76, 0.18),
+			transparent 34rem
+		),
+		linear-gradient(135deg, #0f172a 0%, #111827 50%, #10231a 100%);
+	color: #f8fafc;
+}
+
+:global([data-theme="dark"]) .heroBanner :global(.hero__title) {
+	color: #f8fafc;
+}
+
+:global([data-theme="dark"]) .heroBanner :global(.hero__subtitle) {
+	color: #cbd5e1;
+}
+
+:global([data-theme="dark"]) .heroLogo {
+	filter: drop-shadow(0 18px 34px rgba(106, 176, 76, 0.2));
+}
+
+:global([data-theme="dark"]) .primaryButton {
+	border-color: #6ab04c;
+	background: #6ab04c;
+	color: #0f172a;
+}
+
+:global([data-theme="dark"]) .primaryButton:hover {
+	border-color: #83c966;
+	background: #83c966;
+	color: #0f172a;
+}
+
+:global([data-theme="dark"]) .secondaryButton {
+	border-color: rgba(148, 163, 184, 0.45);
+	background: rgba(15, 23, 42, 0.72);
+	color: #dbeafe;
+}
+
+:global([data-theme="dark"]) .secondaryButton:hover {
+	border-color: #6ab04c;
+	background: rgba(16, 35, 26, 0.9);
+	color: #ffffff;
 }

--- a/packages/documentation/src/pages/index.tsx
+++ b/packages/documentation/src/pages/index.tsx
@@ -11,7 +11,7 @@ function HomepageHeader() {
 	const logoUrl = useBaseUrl("img/logo.svg");
 
 	return (
-		<header className={clsx("hero hero--primary", styles.heroBanner)}>
+		<header className={clsx("hero", styles.heroBanner)}>
 			<div className="container">
 				<img className={styles.heroLogo} src={logoUrl} alt="gmap-vue logo" />
 				<Heading as="h1" className="hero__title">
@@ -23,13 +23,13 @@ function HomepageHeader() {
 				</p>
 				<div className={styles.buttons}>
 					<Link
-						className="button button--secondary button--lg"
+						className={clsx("button button--lg", styles.primaryButton)}
 						to="/docs/vue-3-version/"
 					>
 						Start with Vue 3
 					</Link>
 					<Link
-						className="button button--outline button--secondary button--lg"
+						className={clsx("button button--lg", styles.secondaryButton)}
 						to="/docs/vue-2-version/"
 					>
 						Vue 2 legacy docs


### PR DESCRIPTION
## Summary

- replace the green hero block with a light brand-aligned gradient
- keep the logo readable against the page background
- convert literal backtick text in homepage feature copy to real inline code
- add subtle feature cards and branded homepage buttons

## Validation

- pnpm run --filter docs typecheck
- pnpm run --filter docs build

## Review notes

Fresh review returned GO, no blockers.

`research.md` remains untracked and is not part of this PR.
