### PR TITLE
docs(root): refresh repository guidance

### DIFF
--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -36,10 +36,10 @@ Generated during SDD init on 2026-05-17.
 
 **Trigger**: Work in `packages/documentation/`, Docusaurus docs, guides, API reference, blog, release notes.
 
-- Docusaurus 3.6.3 site lives under `packages/documentation` with base URL `/gmap-vue/`.
+- Docusaurus 3.10.1 site lives under `packages/documentation` with base URL `/gmap-vue/`.
 - Use `docs/vue-2-version/` and `docs/vue-3-version/` for versioned user docs.
 - Validate docs with `pnpm run --filter docs build` and `pnpm run --filter docs typecheck` when relevant.
-- Expected docs warnings include missing blog author/truncation markers and known broken anchors.
+- Docs build should pass without new broken links or anchors; legacy warnings must be called out when unavoidable.
 - Use commit scope `(docs)` for docs-only commits.
 
 ### TestingExpert
@@ -69,7 +69,7 @@ Generated during SDD init on 2026-05-17.
 - Commits MUST use `type(scope): subject`; scope is required and limited to `v2`, `v3`, `next`, `docs`, `root`, `all`.
 - Subject must be lowercase and at least 15 characters.
 - v3 release tags use `gmv3_v${version}` and v2 release tags use `gmv2_v${version}`.
-- Main publish workflow builds/tests/publishes v3; documentation deploys through a separate workflow.
+- CI validates v3 build/test/e2e; manual `release.yml` publishes v3 with semantic-release or guarded prepared-version publishing.
 - Never add AI attribution or `Co-Authored-By` trailers.
 
 ### MonorepoArchitect
@@ -77,10 +77,10 @@ Generated during SDD init on 2026-05-17.
 **Trigger**: Workspace scripts, dependency management, package coordination, root-level validation.
 
 - Repo is a pnpm workspace over `packages/**`, excluding `packages/**/dist/**`.
-- Real root package manager currently declares `pnpm@10.32.1`.
+- Real root package manager currently declares `pnpm@11.7.0`.
 - Root scripts: `build:all`, `test`, `test:e2e`, `lint`, `serve:docs`, `clean`.
 - After code changes, project instructions require root `pnpm run lint`, `pnpm run test`, then `pnpm run test:e2e` in that order.
-- `.node-version` is `24`; CI currently uses Node 20, 22, and 24 for tests.
+- CI uses Node 22 and 24; pnpm 11 requires Node >=22.13.
 
 ## User skills selected for this repository
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,15 +5,14 @@
 **GmapVue** is a Vue plugin that wraps the Google Maps JavaScript API into Vue components. This is a **pnpm workspace monorepo** forked from vue2-google-maps, containing:
 
 - **Vue 2 plugin** (`packages/v2`) - Version 3.5.4 published as `@gmap-vue/v2`
-- **Vue 3 plugin** (`packages/v3`) - Version 2.1.5 published as `@gmap-vue/v3` (primary package)
+- **Vue 3 plugin** (`packages/v3`) - Version 2.2.1 published as `@gmap-vue/v3` (primary package)
 - **Docusaurus documentation** (`packages/documentation`) - Published to GitHub Pages
-- **Legacy documentation** (`packages/old-documentation`) - Archived v1 docs
 
 **Key Technologies:**
 
-- Package Manager: **pnpm 9.13.2** (specified in `packageManager` field)
+- Package Manager: **pnpm 11.7.0** (specified in `packageManager` field)
 - Node Version: **LTS (latest)** - specified in `.node-version` as `24`
-- CI uses: **Node 18.x, 20.x, 22.x** on **ubuntu-latest and windows-latest**
+- CI uses: **Node 22.x and 24.x**. pnpm 11 requires Node >=22.13.
 - Build Tools: Vite (v3), Rollup (v2), TypeScript, Vue SFC compiler
 - Testing: Vitest (unit tests), Cypress (e2e tests)
 - Linting: ESLint (flat config), Prettier
@@ -40,7 +39,6 @@
    Expected warnings (safe to ignore):
    - `DeprecationWarning: url.parse() behavior is not standardized` - From pnpm itself
    - `husky - install command is DEPRECATED` - Still functional
-   - `Snyk protect was removed at 31 March 2022` - From old-documentation package
    - Installation takes approximately **6-10 seconds**
 
 ### Building
@@ -52,7 +50,7 @@ pnpm run build:all
 ```
 
 - Builds v2, v3, and documentation packages
-- Takes approximately **15-20 seconds**
+- Takes approximately **15-30 seconds**
 - Outputs to `packages/*/dist/` directories
 
 **Build individual packages:**
@@ -72,8 +70,7 @@ cd packages/documentation && pnpm run build
 
 - `Browserslist: browsers data (caniuse-lite) is 17 months old` - Ignore or update with `npx update-browserslist-db@latest`
 - v2 rollup warning: "Mixing named and default exports" - Known issue, doesn't affect functionality
-- Documentation warnings about blog authors and truncation markers - Cosmetic only
-- Documentation warnings about broken anchors - Known issues in legacy docs
+- Documentation builds should not introduce new broken links or anchors; investigate warnings when they appear
 
 ### Testing
 
@@ -85,7 +82,7 @@ pnpm run test
 
 - Runs unit tests across all packages using `test:ci` script
 - Takes approximately **3-5 seconds**
-- Currently only v3 has tests (21 test files, 86 tests)
+- Currently only v3 has substantive tests
 - v2 has placeholder: `echo 'not implemented yet'`
 
 **Run v3 tests directly:**
@@ -139,8 +136,8 @@ pnpm run serve:docs
 ```
 
 - Starts Docusaurus dev server at http://localhost:3000/gmap-vue/
-- Takes approximately **15-20 seconds** to compile
-- Expected warnings: Docusaurus update available, blog authors, truncation markers
+- Takes approximately **15-30 seconds** to compile
+- Investigate new Docusaurus warnings instead of treating them as expected noise
 
 ### Pre-commit Validation
 
@@ -180,7 +177,7 @@ type(scope): subject
 feat(v3): add polygon editing support
 fix(v2): resolve marker clustering memory leak
 docs(docs): update installation guide
-chore(root): update pnpm to 9.13.2
+chore(root): update pnpm to 11.7.0
 ```
 
 ## Project Layout & Architecture
@@ -191,8 +188,9 @@ chore(root): update pnpm to 9.13.2
 .
 ├── .github/                    # CI/CD workflows and GitHub config
 │   ├── workflows/
-│   │   ├── publish.yml        # Main CI: build, test, publish (Node 18/20/22)
-│   │   └── documentation.yml  # Docs deployment to gh-pages
+│   │   ├── ci.yml            # Main CI: build, test, e2e matrix
+│   │   ├── release.yml       # Manual v3 release workflow
+│   │   └── documentation.yml # Docs deployment to gh-pages
 │   └── [other github configs]
 ├── packages/                   # Monorepo packages
 │   ├── v2/                    # Vue 2 plugin (@gmap-vue/v2)
@@ -297,15 +295,15 @@ packages/documentation/
 **Documentation-specific notes:**
 
 - Build output goes to `build/` directory
-- Uses Docusaurus 3.6.3 (update available to 3.9.2)
+- Uses Docusaurus 3.10.1
 - Published to `gh-pages` branch via documentation.yml workflow
-- **HACK:** documentation.yml removes `pnpm-workspace.yaml` before build to isolate docs dependencies
+- documentation.yml keeps the root workspace visible, installs with `--ignore-scripts`, then runs docs typecheck/build
 
 ## CI/CD Pipeline & Validation
 
-### Publish Workflow (.github/workflows/publish.yml)
+### CI Workflow (.github/workflows/ci.yml)
 
-Runs on: **push to master** and **all PRs**
+Runs on: **push to master/next** and **all PRs**
 
 **Jobs:**
 
@@ -313,16 +311,15 @@ Runs on: **push to master** and **all PRs**
 2. **build** - Builds v3 package only (artifacts uploaded)
 3. **test** - Matrix strategy:
    - OS: ubuntu-latest, windows-latest
-   - Node: 18.x, 20.x, 22.x
+   - Node: 22.x on Ubuntu/Windows, plus 24.x on Ubuntu
    - Test plans: `test`, `test:e2e`
    - Requires `.env` file creation with `VITE_GOOGLE_API_KEY`
-4. **publish** - Only on master, uses semantic-release
 
 **Important:**
 
-- Only v3 is tested and published via CI
-- v2 relies on separate semantic-release setup
-- Tests run on 12 combinations (2 OS × 3 Node versions × 2 test plans)
+- CI validates v3 build/test/e2e plans on the configured Node 22/24 matrix.
+- Publishing is handled by `.github/workflows/release.yml`, which is manually dispatched on `master` and uses npm Trusted Publishing for v3.
+- v2 has package-level release configuration but is not part of the current manual release workflow package choices.
 
 ### Documentation Workflow (.github/workflows/documentation.yml)
 
@@ -330,10 +327,10 @@ Runs on: **push to master only**
 
 **Steps:**
 
-- Installs pnpm globally (version 9.15.2)
-- **CRITICAL WORKAROUND:** Removes `pnpm-workspace.yaml` before install to prevent workspace resolution issues
-- Builds in `packages/documentation` directory
-- Deploys to `gh-pages` branch using crazy-max/ghaction-github-pages@v4
+- Uses Node 22 and Corepack for pnpm
+- Installs from the root workspace with `--ignore-scripts`
+- Runs `pnpm run --filter docs typecheck` and `pnpm run --filter docs build`
+- Deploys `packages/documentation/build` to `gh-pages` with crazy-max/ghaction-github-pages@v5
 
 ## Configuration Files
 
@@ -384,16 +381,17 @@ Runs on: **push to master only**
 
 ### 2. Documentation Build in Monorepo
 
-**Issue:** pnpm workspace resolution conflicts with Docusaurus dependencies.
+**Status:** No workspace workaround is required.
 
-**CI Workaround:** Remove `pnpm-workspace.yaml` before building docs:
+Use the root workspace install so pnpm policy stays consistent, then run docs validation through workspace filters:
 
 ```bash
-rm -rf ./pnpm-workspace.yaml
-cd packages/documentation && pnpm install && pnpm run build
+pnpm install --frozen-lockfile --ignore-scripts
+pnpm run --filter docs typecheck
+pnpm run --filter docs build
 ```
 
-**Local Development:** No workaround needed, `pnpm run serve:docs` works from root.
+**Local Development:** `pnpm run serve:docs` works from root.
 
 ### 3. Husky Deprecation Warning
 
@@ -413,7 +411,7 @@ cd packages/documentation && pnpm install && pnpm run build
 
 **Tags:**
 
-- v3: `gmv3_v${version}` (e.g., gmv3_v2.1.5)
+- v3: `gmv3_v${version}` (e.g., gmv3_v2.2.1)
 - v2: `gmv2_v${version}` (e.g., gmv2_v3.5.4)
 
 **Release Rules:**

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 .idea
+.claude/
+.codex/
+.pi/
 
 node_modules
 packages/**/dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,753 +1,177 @@
-# GmapVue - Custom Agents
+# Repository Guidelines
 
-This document defines specialized AI agents for working with the GmapVue monorepo. Each agent has domain-specific expertise to help with different aspects of the project.
+## How to Use This Guide
 
-**Important:** All agents should refer to `.github/copilot-instructions.md` for general repository setup, build processes, and validation steps.
+- Start here for repository-wide norms. GmapVue is a pnpm monorepo with Vue 3, Vue 2 legacy, and Docusaurus packages.
+- Use `.github/copilot-instructions.md` for detailed setup, CI behavior, known warnings, and validation commands.
+- Package-specific guidance in this file applies when the changed files are under the matching package.
+- If guidance conflicts, prefer the most specific package section, then `.github/copilot-instructions.md`, then this file.
 
----
+## Available Skills
 
-## Vue3PluginExpert
+Use these project roles as on-demand skills when planning, implementing, reviewing, or validating work.
 
-**Expertise:** Vue 3 composition API, TypeScript, Google Maps JavaScript API integration, reactive component development
+| Skill | Use When | Primary Paths |
+| --- | --- | --- |
+| `Vue3PluginExpert` | Vue 3 plugin, components, composables, TypeScript, Google Maps API wrappers | `packages/v3/` |
+| `Vue2PluginExpert` | Vue 2 legacy plugin maintenance and compatibility | `packages/v2/` |
+| `DocumentationExpert` | Docusaurus guides, API reference, homepage, navigation, docs build | `packages/documentation/` |
+| `TestingExpert` | Vitest, Cypress, Google Maps mocks, e2e runner | `packages/v3/tests/`, `packages/v3/cypress/` |
+| `BuildConfigExpert` | Vite/Rollup, package exports, declarations, bundle outputs | `packages/v3/vite.config.ts`, `packages/v2/rollup.config.js` |
+| `ReleaseExpert` | semantic-release, Trusted Publishing, workflow publishing, commit scopes | `.github/workflows/`, `packages/*/.releaserc` |
+| `MonorepoArchitect` | pnpm workspace, dependency policy, root scripts, cross-package changes | `package.json`, `pnpm-workspace.yaml`, `.npmrc` |
 
-**Primary Focus:** `packages/v3/` - The main actively developed package
+## Auto-Invoke Guidance
 
-### Responsibilities
+When performing these actions, load or apply the corresponding guidance first.
 
-- Implement new Vue 3 components wrapping Google Maps features
-- Write and maintain composables for Maps API functionality
-- Ensure TypeScript type safety with proper interfaces and types
-- Write unit tests using Vitest
-- Write e2e tests using Cypress
-- Maintain Vue 3 reactivity and composition API best practices
+| Action | Guidance |
+| --- | --- |
+| Modify `packages/v3/src` | `Vue3PluginExpert` |
+| Modify `packages/v2/src` | `Vue2PluginExpert` |
+| Modify docs, sidebars, homepage, or Docusaurus config | `DocumentationExpert` |
+| Add or change unit/e2e tests | `TestingExpert` |
+| Change package exports, Vite, Rollup, or declaration output | `BuildConfigExpert` |
+| Change release, publish, npm, or GitHub Actions release workflows | `ReleaseExpert` |
+| Change workspace dependencies or root scripts | `MonorepoArchitect` |
+| Create or update OpenSpec/Gentle AI artifacts | Use `.atl/skill-registry.md` and `openspec/` context |
 
-### Key Context
+## Project Overview
 
-- **Entry Point:** `packages/v3/src/main.ts`
-- **Components:** `packages/v3/src/components/` (~20 components)
-- **Composables:** `packages/v3/src/composables/` (promise-lazy-builder, resize-bus, shapes-helper, etc.)
-- **Types:** `packages/v3/src/types/` and `packages/v3/src/interfaces/`
-- **Tests:** `packages/v3/tests/` (21 test files, 86 tests with Vitest)
-- **E2E:** `packages/v3/cypress/e2e/`
+| Component | Location | Tech Stack | Status |
+| --- | --- | --- | --- |
+| Vue 3 plugin | `packages/v3/` | Vue 3, TypeScript, Vite, Vitest, Cypress | Active |
+| Vue 2 plugin | `packages/v2/` | Vue 2, JavaScript, Rollup | Legacy maintenance |
+| Documentation | `packages/documentation/` | Docusaurus 3, React, TypeScript | Active |
+| OpenSpec / Gentle AI artifacts | `openspec/`, `.atl/` | SDD/OpenSpec, skill registry | Tracked project context |
 
-### Build & Test Commands
-
-```bash
-cd packages/v3
-
-# Development
-pnpm run dev              # Start Vite dev server
-pnpm run build            # Production build (~3-4 seconds)
-pnpm run build:dev        # Development build (no minification)
-
-# Testing
-pnpm run test             # Interactive Vitest
-pnpm run test:ci          # Single run for CI
-pnpm run coverage         # With coverage report
-pnpm run test:e2e         # Cypress e2e (requires API key in cypress/runner/.env)
-pnpm run test:e2e:ci      # Cypress in CI mode
-
-# Validation
-pnpm run type-check       # TypeScript type checking
-pnpm run lint             # Prettier + ESLint with auto-fix
-```
-
-### Configuration Files
-
-- `vite.config.ts` - Build configuration (CJS + ES formats, vite-plugin-dts)
-- `eslint.config.mjs` - ESLint flat config with TypeScript type checking
-- `vitest.config.ts` - Unit test configuration (jsdom environment)
-- `cypress.config.ts` - E2E test configuration
-- `tsconfig.app.json` - Application TypeScript config (strict mode)
-- `tsconfig.eslint.json` - For ESLint type checking (use this for performance)
-- `tsconfig.vitest.json` - Test TypeScript config
-
-### Important Notes
-
-- **External Dependencies:** Vue, @googlemaps/markerclusterer, google.maps (not bundled)
-- **Type Checking:** Always use `tsconfig.eslint.json` for ESLint to avoid performance issues
-- **E2E Tests:** Require `packages/v3/cypress/runner/.env` with `VITE_GOOGLE_API_KEY=your_key`
-- **Commit Scope:** Use `(v3)` in commit messages for v3-specific changes
-- **Release Tag Format:** `gmv3_v${version}` (e.g., gmv3_v2.1.5)
-
-### Code Style
-
-- Single quotes (Prettier config)
-- 2-space indentation (.editorconfig)
-- TypeScript strict mode enabled
-- Follow Vue 3 recommended practices from ESLint config
-
----
-
-## Vue2PluginExpert
-
-**Expertise:** Vue 2 options API, JavaScript (not TypeScript), Google Maps JavaScript API integration, legacy Vue patterns
-
-**Primary Focus:** `packages/v2/` - Legacy package maintained for Vue 2 users
-
-### Responsibilities
-
-- Maintain existing Vue 2 components
-- Fix bugs in Vue 2 implementation
-- Ensure backward compatibility
-- Address TODOs and technical debt in codebase
-- Follow Vue 2 patterns (mixins, options API)
-
-### Key Context
-
-- **Entry Point:** `packages/v2/src/main.js`
-- **Components:** `packages/v2/src/components/` (Vue 2 SFCs)
-- **Mixins:** `packages/v2/src/mixins/` (map-element, mountable)
-- **Utils:** `packages/v2/src/utils/` (factories, helpers, initializer)
-- **Tests:** Not implemented yet (`echo 'not implemented yet'`)
-
-### Build Commands
+## Development
 
 ```bash
-cd packages/v2
-
-# Build
-pnpm run build            # Production build (~2-3 seconds)
-pnpm run build:dev        # Development build
-pnpm run build:test       # Test build
-pnpm run clean:build      # Clean dist directory
-
-# Validation
-pnpm run lint             # Prettier + ESLint with auto-fix
-pnpm run test             # Not implemented (returns placeholder)
+pnpm install
 ```
 
-### Configuration Files
-
-- `rollup.config.js` - Build configuration (ESM, UMD, UMD minified, IIFE)
-- `.prettierrc.yaml` - Single quotes only
-- ESLint config (embedded in package.json or separate .eslintrc)
-
-### Important Notes
-
-- **Known Warning:** "Mixing named and default exports" - Safe to ignore, documented behavior
-- **External Dependencies:** Vue, @googlemaps/markerclusterer (not bundled)
-- **Output Formats:** ESM (tree-shakeable), UMD, UMD minified, IIFE minified
-- **Commit Scope:** Use `(v2)` in commit messages for v2-specific changes
-- **Release Tag Format:** `gmv2_v${version}` (e.g., gmv2_v3.5.4)
-- **Technical Debt:** Many TODO comments exist - check inline comments before modifying
-- **HACK Alert:** Cluster loaded unconditionally (should be conditional) - see `src/main.js`
-
-### TODOs in Codebase (Important Context)
-
-- Multiple "TODO: analyze" comments about potential refactoring
-- Several disabled ESLint rules needing review
-- Promise-based API that may need simplification
-- Check inline comments before modifying related code
-
-### Code Style
-
-- Single quotes (Prettier config)
-- 2-space indentation (.editorconfig)
-- Follow Vue 2 patterns (options API, mixins)
-- Airbnb JavaScript style guide
-
----
-
-## DocumentationExpert
-
-**Expertise:** Docusaurus, technical writing, API documentation, Markdown, React (for Docusaurus components)
-
-**Primary Focus:** `packages/documentation/` - Docusaurus-based documentation site
-
-### Responsibilities
-
-- Write and update documentation for Vue 2 and Vue 3 plugins
-- Maintain API reference documentation
-- Create guides and tutorials
-- Update blog posts and release notes
-- Manage documentation structure and navigation
-
-### Key Context
-
-- **Docs Directory:** `packages/documentation/docs/`
-  - `vue-2-version/` - v2 plugin documentation
-  - `vue-3-version/` - v3 plugin documentation
-- **Blog:** `packages/documentation/blog/`
-- **Components:** `packages/documentation/src/` (React components)
-- **Static Assets:** `packages/documentation/static/`
-- **Build Output:** `packages/documentation/build/` (deployed to gh-pages)
-
-### Commands
+Root commands:
 
 ```bash
-cd packages/documentation
-
-# Development
-pnpm run start            # Start dev server at http://localhost:3000/gmap-vue/
-pnpm run docusaurus       # Run Docusaurus CLI
-
-# Build & Deploy
-pnpm run build            # Production build (~15 seconds)
-pnpm run serve            # Serve built site locally
-pnpm run deploy           # Deploy to GitHub Pages
-pnpm run typecheck        # TypeScript type checking
-
-# Utilities
-pnpm run clear            # Clear cache
-pnpm run write-translations
-pnpm run write-heading-ids
+pnpm run serve:docs   # Start documentation site
+pnpm run build:all    # Build all workspace packages
+pnpm run test         # Run all package test:ci scripts
+pnpm run test:e2e     # Run all e2e CI scripts
+pnpm run lint         # Run all lint scripts
 ```
 
-### Configuration Files
-
-- `docusaurus.config.ts` - Main Docusaurus configuration
-- `sidebars.ts` - Sidebar navigation structure
-- `constants.ts` - Site constants
-- `tsconfig.json` - TypeScript configuration
-
-### Important Notes
-
-- **Docusaurus Version:** 3.6.3 (update available to 3.9.2)
-- **Base URL:** `/gmap-vue/` (GitHub Pages subdirectory)
-- **Node Requirement:** >= 18.0
-- **Expected Warnings (safe to ignore):**
-  - Blog authors not in authors.yml
-  - Missing truncation markers in blog posts
-  - Broken anchors in legacy docs
-  - Browserslist data outdated
-- **CI Workaround:** Documentation workflow removes `pnpm-workspace.yaml` before build
-- **Commit Scope:** Use `(docs)` in commit messages
-
-### Documentation Structure
-
-```
-docs/
-├── vue-2-version/
-│   ├── guide/          # User guides
-│   ├── api/            # API reference
-│   ├── code/           # Code examples
-│   └── developers/     # Contributing guide
-└── vue-3-version/
-    ├── guide/          # User guides
-    ├── api/            # API reference
-    └── developers/     # Contributing guide
-```
-
-### Code Style
-
-- Follow Docusaurus best practices
-- Use MDX for interactive documentation
-- Keep navigation structure in `sidebars.ts`
-- Add truncation markers (`<!-- truncate -->`) in blog posts
-
----
-
-## TestingExpert
-
-**Expertise:** Vitest, Cypress, test-driven development, mocking Google Maps API, component testing
-
-**Primary Focus:** Testing infrastructure and test coverage for v3 package
-
-### Responsibilities
-
-- Write unit tests for components and composables
-- Write e2e tests for user interactions
-- Maintain test infrastructure and configuration
-- Improve test coverage
-- Debug test failures in CI
-
-### Key Context
-
-- **Unit Tests:** `packages/v3/tests/` (21 files, 86 tests)
-- **E2E Tests:** `packages/v3/cypress/e2e/`
-- **Test Runner:** `packages/v3/cypress/runner/` (Vite-based test app)
-- **Current Coverage:** Good coverage for composables, partial for components
-
-### Test Commands
+Package commands:
 
 ```bash
-cd packages/v3
+# Vue 3
+pnpm run --filter @gmap-vue/v3 build
+pnpm run --filter @gmap-vue/v3 test:ci
+pnpm run --filter @gmap-vue/v3 type-check
+pnpm run --filter @gmap-vue/v3 test:e2e:ci
 
-# Unit Tests (Vitest)
-pnpm run test             # Interactive watch mode
-pnpm run test:ci          # Single run (for CI)
-pnpm run test:unit        # With jsdom environment
-pnpm run coverage         # Generate coverage report
+# Vue 2
+pnpm run --filter @gmap-vue/v2 build
+pnpm run --filter @gmap-vue/v2 lint
 
-# E2E Tests (Cypress)
-pnpm run test:e2e         # Open Cypress UI
-pnpm run test:e2e:ci      # Headless mode (for CI)
-pnpm run test:e2e:build   # Build test runner app
-pnpm run test:e2e:preview # Preview test runner
+# Documentation
+pnpm run --filter docs typecheck
+pnpm run --filter docs build
 ```
 
-### Configuration Files
+## Vue 3 Package Guidelines
 
-- `vitest.config.ts` - Vitest configuration (jsdom, external deps)
-- `cypress.config.ts` - Cypress configuration (baseUrl, specPattern)
-- `packages/v3/cypress/runner/vite.config.mts` - Test runner build config
-- `packages/v3/cypress/tsconfig.json` - Cypress TypeScript config
+- Treat `packages/v3` as the primary package.
+- Entry point: `packages/v3/src/main.ts`.
+- Public package subpaths include root, `components`, `composables`, `keys`, `interfaces`, `types`, and `dist/style.css`.
+- Components wrap Google Maps JavaScript API objects and expose keyed promises through composables.
+- Use Vue 3 Composition API, strict TypeScript, and source-aligned docs/examples.
+- Do not document unsupported deep imports as public API.
+- E2E tests require `packages/v3/cypress/runner/.env` with `VITE_GOOGLE_API_KEY`.
 
-### Test Files by Category
+## Vue 2 Package Guidelines
 
-**Composables (well-covered):**
+- Treat `packages/v2` as legacy maintenance.
+- Preserve backwards compatibility and Vue 2 idioms.
+- Check inline TODO/HACK comments before changing related code.
+- Tests are placeholder-only, so validate with build/lint and careful manual reasoning.
 
-- `promise-lazy-builder.spec.ts`
-- `resize-bus.spec.ts`
-- `shapes-helper.spec.ts`
-- `component-promise-factory.spec.ts`
-- `google-maps-api-initializer.spec.ts`
+## Documentation Guidelines
 
-**Components (partial coverage):**
+- Vue 3 is the primary user journey. Vue 2 is legacy but remains available.
+- Prefer task-first guides before API reference pages.
+- Examples must use documented package entrypoints and current source behavior.
+- Be explicit about Google Maps API key security, billing-sensitive calls, and optional library loading.
+- Avoid examples that trigger repeated paid Google Maps/Places requests from high-frequency map events.
+- Docusaurus base URL is `/gmap-vue/`; use Docusaurus helpers for site assets when editing React pages.
+- Validate docs with `pnpm run --filter docs typecheck` and `pnpm run --filter docs build`.
 
-- `map-layer.spec.ts`
-- `marker-icon.spec.ts`
-- `circle-shape.spec.ts`
-- `polygon-shape.spec.ts`
-- `polyline-shape.spec.ts`
-- `info-window.spec.ts`
-- `cluster-icon.spec.ts`
-- `heatmap-layer.spec.ts`
-- `drawing-manager.spec.ts`
-- `kml-layer.spec.ts`
-- `autocomplete-input.spec.ts`
+## Testing Guidelines
 
-**Plugin & Config:**
+- Unit tests use Vitest in `packages/v3/tests`.
+- E2E tests use Cypress in `packages/v3/cypress/e2e` with the Vite runner under `packages/v3/cypress/runner`.
+- Mock `google.maps` for unit tests; use the real API only in e2e tests with a valid key.
+- For behavior changes in Vue 3, prefer test-first evidence: RED, GREEN, REFACTOR.
 
-- `main.spec.ts`
-- `plugin-component-builder.spec.ts`
-- `plugin-component-config.spec.ts`
-- `helpers.spec.ts`
+## Build and Release Guidelines
 
-### Important Notes
+- v3 builds with Vite and emits CJS, ESM, CSS, and declarations.
+- v2 builds with Rollup and emits ESM/UMD/IIFE artifacts.
+- Publishing uses semantic-release and npm Trusted Publishing where configured.
+- Release tags:
+  - v3: `gmv3_v${version}`
+  - v2: `gmv2_v${version}`
+- Do not commit generated `dist/` artifacts unless an explicit release process requires them.
 
-- **E2E API Key:** Tests require `packages/v3/cypress/runner/.env` with valid Google Maps API key
-- **Test Environment:** Vitest uses jsdom for DOM simulation
-- **External Deps:** `@googlemaps/markerclusterer` and `google.maps` are externalized
-- **Coverage Provider:** v8 (also supports istanbul, c8)
-- **Coverage Location:** `packages/v3/coverage/`
-- **CI Test Matrix:** Runs on 2 OS × 3 Node versions × 2 test plans = 12 combinations
+## Commit and Pull Request Guidelines
 
-### Mocking Strategy
+Use conventional commits with required scopes:
 
-- Google Maps API is typically mocked in unit tests
-- Use actual API in e2e tests with valid key
-- Mock global `google.maps` object structure
-- Consider using `@googlemaps/jest-mocks` patterns
-
-### Test Coverage Goals
-
-1. All new components should have unit tests
-2. All new composables should have unit tests
-3. Critical user flows should have e2e tests
-4. Aim for >80% coverage on new code
-
----
-
-## BuildConfigExpert
-
-**Expertise:** Vite, Rollup, bundling, TypeScript compilation, module formats, build optimization
-
-**Primary Focus:** Build configurations for v2 (Rollup) and v3 (Vite)
-
-### Responsibilities
-
-- Configure and optimize build processes
-- Manage module formats (CJS, ESM, UMD, IIFE)
-- Handle TypeScript declaration generation
-- Optimize bundle sizes
-- Configure external dependencies
-- Debug build issues
-
-### Key Files
-
-**v3 (Vite):**
-
-- `packages/v3/vite.config.ts` - Main Vite configuration
-- `packages/v3/tsconfig.app.json` - TypeScript for build
-- `packages/v3/tsconfig.node.json` - TypeScript for config files
-- Uses `vite-plugin-dts` for declaration generation
-
-**v2 (Rollup):**
-
-- `packages/v2/rollup.config.js` - Rollup configuration
-- Uses `rollup-plugin-vue` for SFC compilation
-- Uses `rollup-plugin-terser` for minification
-
-### Build Configurations
-
-**v3 Build (Vite):**
-
-```javascript
-// Entry points
-{
-  main: './src/main.ts',
-  components: './src/components/index.ts',
-  composables: './src/composables/index.ts',
-  keys: './src/keys/index.ts'
-}
-
-// Output formats: CJS, ES
-// External: vue, @googlemaps/markerclusterer, google.maps
-// TypeScript: declarations in dist/types/
+```text
+<type>(<scope>): <description>
 ```
 
-**v2 Build (Rollup):**
+Allowed types include `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, and `revert`.
 
-```javascript
-// Entry: src/main.js
-// Outputs:
-// - dist/esm/ (tree-shakeable ES modules)
-// - dist/main.js (UMD)
-// - dist/gmap-vue.min.js (UMD minified)
-// - dist/gmap-vue.iife.js (IIFE minified)
-// External: vue, @googlemaps/markerclusterer
-```
+Common scopes:
 
-### Build Commands
+| Scope | Use For |
+| --- | --- |
+| `v3` | Vue 3 package changes |
+| `v2` | Vue 2 package changes |
+| `docs` | Documentation package or docs content |
+| `root` | Root workspace/config changes |
+| `all` | Cross-package changes |
+
+Before opening a PR:
+
+1. Keep the diff focused and reviewable.
+2. Run relevant validation commands.
+3. Include validation evidence and screenshots for UI/docs visual changes.
+4. Mention known external blockers, such as missing Google Maps API key or billing issues.
+
+## Validation Policy
+
+For broad or cross-package changes, run this sequence before considering work complete:
 
 ```bash
-# v3
-cd packages/v3
-pnpm run build            # Production (minified)
-pnpm run build:dev        # Development (not minified)
-pnpm run type-check       # TypeScript checking
-pnpm run type-gen         # Generate declarations only
-
-# v2
-cd packages/v2
-pnpm run build            # Production
-pnpm run build:dev        # Development
-pnpm run build:test       # Test build
-pnpm run clean:build      # Clean dist/
+pnpm run lint
+pnpm run test
+pnpm run test:e2e
 ```
 
-### Important Notes
+If e2e cannot run because of missing credentials or external Google Cloud billing/API configuration, state that explicitly in the PR notes.
 
-- **Minification Control:** v3 uses `VITE_IS_LOCAL_BUILD` env var to disable minification
-- **Declaration Generation:** v3 uses vite-plugin-dts with tsconfig.app.json
-- **Vue SFC Handling:** v3 uses @vitejs/plugin-vue, v2 uses rollup-plugin-vue
-- **CSS Handling:** Both extract CSS separately
-- **Source Maps:** Enable in development builds
-- **Tree Shaking:** Maintained in ESM outputs
+## OpenSpec and Gentle AI Artifacts
 
-### Debugging Build Issues
+- Project SDD/OpenSpec artifacts are stored under `openspec/`.
+- The project skill registry lives at `.atl/skill-registry.md`.
+- Keep these files committed when they represent project decisions, specs, task plans, verification reports, or skill routing.
+- Do not commit local agent runtime/session artifacts from `.pi/`, `.claude/`, or `.codex/` unless a future repo-level policy explicitly introduces a tracked file there.
+- When adding a new substantial change, prefer an OpenSpec change folder with proposal, design, tasks, apply progress, and verification notes.
 
-1. Check Node version matches requirements (LTS)
-2. Clear dist/ directory: `pnpm run clean:build`
-3. Check for TypeScript errors: `pnpm run type-check`
-4. Verify external dependencies are not bundled
-5. Check rollup/vite config for entry points
-6. Review package.json exports field
+## Known External Constraints
 
-### Bundle Analysis
-
-- v3 main bundle: ~42KB (resize-bus component)
-- Components are code-split by default
-- Use Vite's bundle visualizer for analysis
-- Monitor bundle sizes in CI
-
----
-
-## ReleaseExpert
-
-**Expertise:** Semantic versioning, conventional commits, semantic-release, npm publishing, GitHub workflows
-
-**Primary Focus:** Release automation, versioning, and changelog management
-
-### Responsibilities
-
-- Manage semantic releases for v2 and v3
-- Ensure conventional commit compliance
-- Review and update changelogs
-- Debug CI/CD publish workflows
-- Manage npm package publishing
-- Handle version conflicts and dependencies
-
-### Key Files
-
-- `packages/v3/.releaserc` - v3 semantic-release config
-- `packages/v2/.releaserc` - v2 semantic-release config
-- `commitlint.config.js` - Commit message validation
-- `.github/workflows/publish.yml` - Main CI/CD pipeline
-- `.lintstagedrc.yml` - Pre-commit hooks
-- `.husky/pre-commit` - Git hooks
-
-### Semantic Release Configuration
-
-**v3 Release Rules:**
-
-- Tag format: `gmv3_v${version}`
-- Ignores commits with scope: v2, docs, next, root, gmap-vue, gmap-vue-next
-- Publishes to npm as `@gmap-vue/v3`
-- Runs on master branch
-
-**v2 Release Rules:**
-
-- Tag format: `gmv2_v${version}`
-- Ignores commits with scope: v3, docs, next, root, gmap-vue-next
-- Publishes to npm as `@gmap-vue/v2`
-- Runs on master branch
-
-### Commit Message Format (STRICTLY ENFORCED)
-
-**Pattern:**
-
-```
-type(scope): subject
-
-[optional body]
-
-[optional footer]
-```
-
-**Rules (from commitlint.config.js):**
-
-- **Type (required):** feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
-- **Scope (REQUIRED):** v2, v3, next, docs, root, all
-- **Subject:** 15-100 chars, lowercase
-- **Body:** Max 1000 chars, blank line before required
-- **Footer:** Max 300 chars, blank line before required
-
-**Examples:**
-
-```bash
-# Good commits
-feat(v3): add street view panorama component
-fix(v2): resolve marker icon memory leak
-docs(docs): update API reference for circle component
-chore(root): upgrade pnpm to 9.13.2
-
-# Bad commits (will fail CI)
-feat: add new feature              # ❌ Missing scope
-Fix(v3): bug fix                   # ❌ Capitalized type
-feat(v3): add                      # ❌ Subject too short (< 15 chars)
-feat(all): Update something        # ❌ Capitalized subject
-```
-
-### CI/CD Pipeline
-
-**Publish Workflow Stages:**
-
-1. **install-and-cache** (Node 22.x, pnpm)
-2. **build** (v3 only, uploads artifacts)
-3. **test** (Matrix: 2 OS × 3 Node × 2 test plans)
-4. **publish** (master only, semantic-release)
-
-**Test Matrix:**
-
-- OS: ubuntu-latest, windows-latest
-- Node: 18.x, 20.x, 22.x
-- Plans: test, test:e2e
-- Total: 12 test combinations
-
-**Publish Steps:**
-
-1. Checkout code
-2. Setup pnpm and Node
-3. Install dependencies (frozen lockfile)
-4. Configure git credentials
-5. Run semantic-release (determines version, creates changelog)
-6. Publish to npm
-
-### Release Commands
-
-```bash
-# Manual release (if needed)
-cd packages/v3
-pnpm run release          # Runs semantic-release
-
-cd packages/v2
-pnpm run release          # Runs semantic-release
-```
-
-### Important Notes
-
-- **Automatic Releases:** Triggered on merge to master with proper commits
-- **Version Determination:** semantic-release analyzes commits since last release
-- **Breaking Changes:** Use `BREAKING CHANGE:` in footer or `!` after scope
-- **Pre-commit Validation:** Husky runs lint-staged on staged files
-- **Commit Validation:** commitlint validates message format before commit
-- **NPM Authentication:** Uses NPM_TOKEN secret in GitHub
-- **Git Authentication:** Uses GH_TOKEN_REPO secret in GitHub
-
-### Debugging Release Issues
-
-1. **Release Not Triggered:** Check commit messages match rules
-2. **Wrong Version Bump:** Review commit types (feat=minor, fix=patch)
-3. **Publish Failed:** Check npm authentication and package access
-4. **Build Artifacts Missing:** Ensure build job completed successfully
-5. **Tag Conflicts:** Check for existing tags with same version
-
-### Pre-release Checklist
-
-- [ ] All tests passing (pnpm run test)
-- [ ] Build succeeds (pnpm run build:all)
-- [ ] Linting passes (pnpm run lint)
-- [ ] Commits follow conventional format
-- [ ] Changelog reviewed (auto-generated)
-- [ ] Breaking changes documented
-- [ ] Version bump appropriate for changes
-
----
-
-## MonorepoArchitect
-
-**Expertise:** pnpm workspaces, monorepo management, dependency management, workspace protocol
-
-**Primary Focus:** Overall monorepo structure and cross-package coordination
-
-### Responsibilities
-
-- Manage workspace dependencies
-- Configure pnpm workspace settings
-- Handle inter-package dependencies
-- Optimize workspace workflows
-- Manage shared configurations
-- Coordinate builds across packages
-
-### Key Files
-
-- `pnpm-workspace.yaml` - Workspace definition
-- `package.json` (root) - Workspace scripts
-- `.npmrc` - pnpm configuration
-- `.editorconfig` - Shared editor settings
-- `.lintstagedrc.yml` - Lint-staged configuration
-
-### Workspace Structure
-
-```yaml
-packages:
-  - "packages/**" # All packages
-  - "!packages/**/dist/**" # Exclude dist directories
-```
-
-### Workspace Scripts
-
-```bash
-# From root directory
-pnpm run serve:docs        # Start documentation server
-pnpm run build:all         # Build all packages recursively
-pnpm run test              # Run all tests (test:ci)
-pnpm run test:e2e          # Run all e2e tests
-pnpm run lint              # Lint all packages
-pnpm run clean             # Remove all node_modules and locks
-```
-
-### Package Management
-
-**Current Packages:**
-
-1. **@gmap-vue/v3** (v2.1.5) - Main package
-2. **@gmap-vue/v2** (v3.5.4) - Legacy package
-3. **docs** (private) - Documentation site
-4. **old-docs** (private) - Archived documentation
-
-### Dependency Management
-
-- **pnpm Version:** 9.13.2 (specified in packageManager field)
-- **Node Version:** LTS (lts-latest via fnm)
-- **Workspace Protocol:** Automatic for inter-package deps
-- **Frozen Lockfile:** Used in CI (`--frozen-lockfile --ignore-scripts`)
-
-### Important Notes
-
-- **Shared Dev Dependencies:** At root level (@commitlint, husky, lint-staged)
-- **Package-specific Dependencies:** In each package's package.json
-- **HACK in CI:** Documentation workflow removes pnpm-workspace.yaml to isolate deps
-- **Recursive Commands:** Use `pnpm run --recursive <script>` for all packages
-- **Filtering:** Use `pnpm run --filter <package> <script>` for specific package
-
-### Common Tasks
-
-**Add dependency to specific package:**
-
-```bash
-pnpm add <package> --filter @gmap-vue/v3
-pnpm add -D <package> --filter @gmap-vue/v2
-```
-
-**Update all dependencies:**
-
-```bash
-pnpm update --recursive
-```
-
-**Clean and reinstall:**
-
-```bash
-pnpm run clean          # Remove node_modules, locks
-pnpm install           # Fresh install
-```
-
-### Workspace Best Practices
-
-1. Keep shared configs at root level
-2. Run validation from root when possible
-3. Use workspace protocol for inter-package deps
-4. Keep lockfile committed
-5. Run `pnpm install` after pulling changes
-6. Test packages independently before integration
-7. Follow monorepo commit scope conventions
-
-### Debugging Workspace Issues
-
-1. Check pnpm version: `pnpm --version`
-2. Verify workspace config: `pnpm-workspace.yaml`
-3. Check package linking: `pnpm list --depth=0`
-4. Clear cache: `pnpm store prune`
-5. Reinstall: `pnpm run clean && pnpm install`
-
----
-
-## General Guidelines for All Agents
-
-### Pre-flight Checklist
-
-1. Read `.github/copilot-instructions.md` for setup and build processes
-2. Ensure Node LTS installed: `fnm install lts-latest && fnm use lts-latest`
-3. Install dependencies: `pnpm install`
-4. Verify build works: `pnpm run build:all`
-5. Check tests pass: `pnpm run test`
-
-### Before Making Changes
-
-1. Identify which package(s) affected (v2, v3, docs, root)
-2. Read relevant configuration files
-3. Check for TODOs or HACKs in related code
-4. Review existing tests for patterns
-
-### After Making Changes
-
-**CRITICAL: Always run these three commands from the repository root in this exact order and fix any errors before considering the task done:**
-
-```bash
-pnpm run lint      # Must exit 0 — fix all ESLint/Prettier errors before proceeding
-pnpm run test      # Must exit 0 — fix all failing unit tests before proceeding
-pnpm run test:e2e  # Must exit 0 — fix all failing e2e tests before proceeding
-```
-
-Do not skip any of these steps. Do not proceed to commit or hand back to the user if any of them fails.
-
-1. Run package-specific build: `cd packages/<name> && pnpm run build`
-2. Run linting from root: `pnpm run lint`
-3. Run unit tests from root: `pnpm run test`
-4. Run e2e tests from root: `pnpm run test:e2e`
-5. Verify types (v3): `pnpm run type-check`
-6. Write commit with proper conventional format
-7. Ensure commit message follows rules (scope required!)
-
-### Getting Help
-
-- General setup and build: `.github/copilot-instructions.md`
-- Contributing guidelines: Embedded in documentation
-- Commit format: `commitlint.config.js`
-- Workflow details: `.github/workflows/`
-
-### Communication Style
-
-- Be specific about which package you're working in
-- Reference file paths from package root when possible
-- Mention timing estimates for long-running commands
-- Warn about expected errors or warnings
-- Provide examples for commit messages
-
----
-
-**Remember:** This is a monorepo with independent release cycles for v2 and v3. Always specify which package you're working with using the correct scope in commits: `(v2)`, `(v3)`, `(docs)`, `(root)`, or `(all)`.
+- Google Maps e2e tests require a valid API key and enabled billing.
+- `BillingNotEnabledMapError` indicates external Google Cloud billing setup, not necessarily a code failure.
+- Legacy Vue 2 docs/code may contain old references; avoid broad cleanup unless it is the PR scope.

--- a/README.md
+++ b/README.md
@@ -4,51 +4,129 @@
   <img src="packages/documentation/static/img/logo.svg" alt="gmap-vue logo" width="260" />
 </p>
 
-[![Publish](https://github.com/diegoazh/gmap-vue/workflows/publish/badge.svg)](https://github.com/diegoazh/gmap-vue/actions?query=workflow%3Apublish)
-[![Documentation](https://github.com/diegoazh/gmap-vue/workflows/documentation/badge.svg)](https://github.com/diegoazh/gmap-vue/actions?query=workflow%3Adocumentation)
+<p align="center">
+  Google Maps components and composables for Vue 3, with legacy Vue 2 support.
+</p>
 
-A Vue plugin that wraps the Google Map API into different Vue components.
+<p align="center">
+  <a href="https://github.com/diegoazh/gmap-vue/actions/workflows/ci.yml"><img src="https://github.com/diegoazh/gmap-vue/actions/workflows/ci.yml/badge.svg" alt="CI workflow status" /></a>
+  <a href="https://github.com/diegoazh/gmap-vue/actions?query=workflow%3Adocumentation"><img src="https://github.com/diegoazh/gmap-vue/workflows/documentation/badge.svg" alt="Documentation workflow status" /></a>
+</p>
 
-## [Documentation](https://diegoazh.github.io/gmap-vue/)
+## Overview
 
-You can find the documentation following the [link](https://diegoazh.github.io/gmap-vue/).
+GmapVue is a pnpm monorepo that provides Vue wrappers for the Google Maps JavaScript API.
 
-## Plugin dependencies
+- **Vue 3 package:** `@gmap-vue/v3`, the actively developed package.
+- **Vue 2 package:** `@gmap-vue/v2`, maintained for legacy applications.
+- **Documentation:** Docusaurus site published at <https://diegoazh.github.io/gmap-vue/>.
 
-|Name|Version|
-|----|-------|
-|*vue*|[![npm version](https://badge.fury.io/js/vue.svg)](https://www.npmjs.com/package/vue?activeTab=readme)|
-|*@googlemaps/markerclusterer*|[![npm version](https://badge.fury.io/js/@googlemaps%2Fmarkerclusterer.svg)](https://badge.fury.io/js/@googlemaps%2Fmarkerclusterer)|
-|*lodash.isEqual*|[![npm version](https://badge.fury.io/js/lodash.isequal.svg)](https://www.npmjs.com/package/lodash.isequal)|
-|*mitt*|[![npm version](https://badge.fury.io/js/mitt.svg)](https://www.npmjs.com/package/mitt)|
+The project is a maintained fork of `vue2-google-maps`, updated to support modern Vue, typed package entrypoints, and component-level access to Google Maps instances.
 
-## Fork of vue2-google-maps
+## Documentation
 
-This is a fork of the popular vue2-google-maps. As the author of the library no longer commits to maintain the project, we forked it to develop and maintain the project.
+Start with the published docs:
 
-## Workspaces
+- [Vue 3 documentation](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/)
+- [Vue 2 legacy documentation](https://diegoazh.github.io/gmap-vue/docs/vue-2-version/)
+- [Component API reference](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/api/components/)
 
-This project uses [pnpm](https://pnpm.io/es/) workspaces to manage the plugin and documentation site. You will find the version of this plugin for Vue 2 on [`packages/v2`](https://github.com/diegoazh/gmap-vue/blob/master/packages/v2/README.md) folder, the version for Vue 3 on the [`packages/v3`](https://github.com/diegoazh/gmap-vue/blob/master/packages/v3/README.md) folder and the documentation on [`packages/documentation`](https://github.com/diegoazh/gmap-vue/blob/master/packages/documentation/README.md) folder.
+## Packages
 
-- Clone the repository and run
+| Package | Location | Status | Purpose |
+| --- | --- | --- | --- |
+| `@gmap-vue/v3` | `packages/v3` | Active | Vue 3 plugin, components, composables, keys, interfaces, and types. |
+| `@gmap-vue/v2` | `packages/v2` | Legacy | Vue 2 plugin maintained for existing applications. |
+| `docs` | `packages/documentation` | Active | Docusaurus documentation site. |
 
-  - `pnpm`
+## Install
 
-    ```sh
-    pnpm install
-    ```
+```bash
+pnpm add @gmap-vue/v3
+```
 
-- To start the documentation site locally you can run the below command, it starts the documentation page on [http://localhost:8080/](http://localhost:8080/)
+Peer/runtime dependencies are resolved by your app, including Vue and the Google Maps JavaScript API types used by your tooling.
 
-  ```sh
-  pnpm run serve:docs
-  ```
+## Vue 3 quick start
 
-## CONTRIBUTORS ARE WELCOME
+```ts title="main.ts"
+import { createApp } from 'vue';
+import { createGmapVuePlugin } from '@gmap-vue/v3';
+import '@gmap-vue/v3/dist/style.css';
+import App from './App.vue';
 
-If you have time to contribute to a rather frequently used library, feel free to make a PR!, but first please read our [contributing guide](https://github.com/diegoazh/gmap-vue/blob/master/CONTRIBUTING.md).
+createApp(App)
+  .use(
+    createGmapVuePlugin({
+      load: {
+        key: import.meta.env.VITE_GOOGLE_MAPS_API_KEY,
+      },
+    }),
+  )
+  .mount('#app');
+```
 
-What's urgently needed are:
+```vue title="MapExample.vue"
+<template>
+  <GmvMap
+    :center="{ lat: -34.6037, lng: -58.3816 }"
+    :zoom="12"
+    style="width: 100%; height: 500px"
+  />
+</template>
+```
 
-1. Better unit tests (we use Vitest).
-2. Better integration tests (we use Cypress)
+For production apps, restrict browser API keys in Google Cloud Console by HTTP referrer and by required APIs.
+
+## Development
+
+This repository uses pnpm workspaces.
+
+```bash
+pnpm install
+```
+
+Common root commands:
+
+```bash
+pnpm run serve:docs   # Start the Docusaurus site
+pnpm run build:all    # Build workspace packages
+pnpm run test         # Run package test:ci scripts
+pnpm run test:e2e     # Run package e2e CI scripts
+pnpm run lint         # Run workspace lint scripts
+```
+
+Package-specific examples:
+
+```bash
+pnpm run --filter @gmap-vue/v3 build
+pnpm run --filter @gmap-vue/v3 test:ci
+pnpm run --filter @gmap-vue/v3 type-check
+pnpm run --filter docs build
+pnpm run --filter docs typecheck
+```
+
+## Validation before opening a PR
+
+Run the checks that match your change. For broad changes, use the full root validation path:
+
+```bash
+pnpm run lint
+pnpm run test
+pnpm run test:e2e
+```
+
+E2E tests require `packages/v3/cypress/runner/.env` with `VITE_GOOGLE_API_KEY`. If Google Cloud billing or API key restrictions are not correctly configured, e2e tests can fail with Google Maps runtime errors.
+
+## Contributing
+
+Contributions are welcome. Before opening a PR:
+
+1. Read [`AGENTS.md`](AGENTS.md) and [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+2. Keep changes scoped and reviewable.
+3. Use conventional commits with a required scope, for example `docs(docs): improve vue 3 guide`.
+4. Include validation evidence in the PR description.
+
+## License
+
+MIT. See package-level license files where applicable.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,43 @@
+project: gmap-vue
+name: GmapVue
+summary: Vue wrappers, composables, and documentation for the Google Maps JavaScript API.
+
+artifact_store:
+  primary: openspec
+  skill_registry: .atl/skill-registry.md
+
+packages:
+  vue3:
+    path: packages/v3
+    status: active
+    validation:
+      - pnpm run --filter @gmap-vue/v3 build
+      - pnpm run --filter @gmap-vue/v3 test:ci
+      - pnpm run --filter @gmap-vue/v3 type-check
+  vue2:
+    path: packages/v2
+    status: legacy
+    validation:
+      - pnpm run --filter @gmap-vue/v2 build
+      - pnpm run --filter @gmap-vue/v2 lint
+  documentation:
+    path: packages/documentation
+    status: active
+    validation:
+      - pnpm run --filter docs typecheck
+      - pnpm run --filter docs build
+
+quality_gates:
+  broad_changes:
+    - pnpm run lint
+    - pnpm run test
+    - pnpm run test:e2e
+  notes:
+    - E2E tests require packages/v3/cypress/runner/.env with VITE_GOOGLE_API_KEY.
+    - Google Maps billing/API-key configuration can block e2e independently of repository code.
+
+sdd:
+  default_mode: interactive
+  strict_tdd: true
+  review_budget_changed_lines: 400
+  chained_pr_strategy: auto-forecast

--- a/packages/documentation/README.md
+++ b/packages/documentation/README.md
@@ -1,6 +1,21 @@
-# GmapVue documentation site
+# GmapVue documentation
 
-This package contains the Docusaurus documentation site published at `https://diegoazh.github.io/gmap-vue/`.
+This package contains the Docusaurus 3 site for GmapVue, published at <https://diegoazh.github.io/gmap-vue/>.
+
+The docs site is part of the root pnpm workspace and should be developed from the repository root whenever possible so workspace dependency policy stays consistent.
+
+## Structure
+
+```text
+packages/documentation/
+├── docs/
+│   ├── vue-2-version/      # Legacy Vue 2 documentation
+│   └── vue-3-version/      # Primary Vue 3 documentation
+├── src/                    # Docusaurus React components, CSS, and pages
+├── static/                 # Static assets served by Docusaurus
+├── docusaurus.config.ts    # Site configuration
+└── sidebars.ts             # Sidebar navigation
+```
 
 ## Local development
 
@@ -17,16 +32,20 @@ cd packages/documentation
 pnpm run start
 ```
 
-## Validate docs changes
+The site runs at <http://localhost:3000/gmap-vue/>.
 
-Run these before opening a documentation PR:
+## Validation
+
+Run these before opening or updating a documentation PR:
 
 ```bash
 pnpm run --filter docs typecheck
 pnpm run --filter docs build
 ```
 
-The build output is generated under `packages/documentation/build/` and should not be edited manually.
+For broad repository changes, also follow the root validation guidance in `../../AGENTS.md`.
+
+The production build is generated under `packages/documentation/build/`. Do not edit generated files manually.
 
 ## Content direction
 
@@ -38,3 +57,23 @@ When adding or changing docs:
 2. Keep API reference pages behind guide pages.
 3. Avoid Docusaurus starter content, placeholder examples, or generic community links.
 4. Prefer working Vue 3 examples with documented package entrypoints.
+5. Keep examples aligned with source behavior, not intended future behavior.
+6. Be explicit about Google Maps API key restrictions, enabled APIs, billing, and optional library loading.
+7. Avoid examples that call paid Google Maps or Places APIs from high-frequency events such as `tilesloaded`.
+
+## Navigation
+
+- Use `sidebars.ts` for curated Vue 3 navigation.
+- Keep Vue 2 navigation legacy-friendly and avoid large unrelated cleanups unless that is the PR scope.
+- Add new component guides near related guides, then add matching API pages when the public API needs explicit reference material.
+
+## Deployment
+
+The `documentation` GitHub Actions workflow builds the docs with:
+
+```bash
+pnpm run --filter docs typecheck
+pnpm run --filter docs build
+```
+
+It deploys `packages/documentation/build/` to the `gh-pages` branch. The site uses Docusaurus `baseUrl: '/gmap-vue/'`, so links and assets must work under that subpath.

--- a/packages/documentation/docs/vue-2-version/changelog/changelog.md
+++ b/packages/documentation/docs/vue-2-version/changelog/changelog.md
@@ -4,6 +4,21 @@ title: Changelog
 sidebar_position: 5
 sidebar_label: Changelog
 ---
+## [3.5.4](https://github.com/diegoazh/gmap-vue/compare/v3.5.3...v3.5.4) (2022-08-06)
+
+
+### Bug Fixes
+
+* **gmap-vue:** document is undefined ssr ([5b97124](https://github.com/diegoazh/gmap-vue/commit/5b971249bed2cec7a61bcd5a0255f00d2fe354da))
+* **gmap-vue:** remove optional conditional operator ([0613d8e](https://github.com/diegoazh/gmap-vue/commit/0613d8e6df4fb539547b0be9004074e8918e5807))
+
+## [3.5.3](https://github.com/diegoazh/gmap-vue/compare/v3.5.2...v3.5.3) (2022-07-29)
+
+
+### Bug Fixes
+
+* **gmap-vue:** remove core and runtime from package.json ([4b803d3](https://github.com/diegoazh/gmap-vue/commit/4b803d3d540a9cff576b9432bb2f3de133b72818)), closes [#274](https://github.com/diegoazh/gmap-vue/issues/274)
+
 ## [3.5.2](https://github.com/diegoazh/gmap-vue/compare/v3.5.1...v3.5.2) (2022-03-12)
 
 

--- a/packages/documentation/docs/vue-3-version/changelog/changelog.md
+++ b/packages/documentation/docs/vue-3-version/changelog/changelog.md
@@ -4,6 +4,68 @@ title: Changelog
 sidebar_position: 5
 sidebar_label: Changelog
 ---
+## [2.2.1](https://github.com/diegoazh/gmap-vue/compare/gmv3_v2.2.0...gmv3_v2.2.1) (2026-06-08)
+
+
+### Bug Fixes
+
+* **all:** handle removed drawing library ([#375](https://github.com/diegoazh/gmap-vue/issues/375)) ([753170e](https://github.com/diegoazh/gmap-vue/commit/753170e283ad785bccceb114bb364cd6c17725ee)), closes [#374](https://github.com/diegoazh/gmap-vue/issues/374) [#374](https://github.com/diegoazh/gmap-vue/issues/374)
+* **docs:** publish docusaurus output root ([#370](https://github.com/diegoazh/gmap-vue/issues/370)) ([f2e5e87](https://github.com/diegoazh/gmap-vue/commit/f2e5e87266bbeed9faa968ca479e153507dde8c5))
+* **v3:** update info window position ([#376](https://github.com/diegoazh/gmap-vue/issues/376)) ([65fa261](https://github.com/diegoazh/gmap-vue/commit/65fa26136c26579a0f97c2de8706658e3e7a0a53)), closes [#367](https://github.com/diegoazh/gmap-vue/issues/367) [#367](https://github.com/diegoazh/gmap-vue/issues/367) [#367](https://github.com/diegoazh/gmap-vue/issues/367)
+
+# [2.2.0](https://github.com/diegoazh/gmap-vue/compare/gmv3_v2.1.8...gmv3_v2.2.0) (2026-03-16)
+
+
+### Features
+
+* **v3:** add duplicate key detection and warning for component promise factory ([#361](https://github.com/diegoazh/gmap-vue/issues/361)) ([2724a84](https://github.com/diegoazh/gmap-vue/commit/2724a845e8a9d3cb70f44389cb4de55794236f6c)), closes [#321](https://github.com/diegoazh/gmap-vue/issues/321)
+
+## [2.1.8](https://github.com/diegoazh/gmap-vue/compare/gmv3_v2.1.7...gmv3_v2.1.8) (2026-03-16)
+
+
+### Bug Fixes
+
+* **v3:** replace the broken call with a direct watch on the two computed-ref sources ([#360](https://github.com/diegoazh/gmap-vue/issues/360)) ([8ce5345](https://github.com/diegoazh/gmap-vue/commit/8ce5345fa578c8247a93fdceeb175a8adb2735bb)), closes [#348](https://github.com/diegoazh/gmap-vue/issues/348)
+
+## [2.1.7](https://github.com/diegoazh/gmap-vue/compare/gmv3_v2.1.6...gmv3_v2.1.7) (2026-03-15)
+
+
+### Bug Fixes
+
+* **v3:** change map center or marker position reactivity ([#359](https://github.com/diegoazh/gmap-vue/issues/359)) ([94ee0f7](https://github.com/diegoazh/gmap-vue/commit/94ee0f71ab0fc1faa028d3cdae69bb2774e7939b)), closes [#350](https://github.com/diegoazh/gmap-vue/issues/350)
+
+## [2.1.6](https://github.com/diegoazh/gmap-vue/compare/gmv3_v2.1.5...gmv3_v2.1.6) (2026-03-15)
+
+
+### Bug Fixes
+
+* **v3:** lodash.isEqual deprecation warning ([#358](https://github.com/diegoazh/gmap-vue/issues/358)) ([bbe6864](https://github.com/diegoazh/gmap-vue/commit/bbe6864344d706f40104642a65904113f1e7ac89)), closes [#353](https://github.com/diegoazh/gmap-vue/issues/353)
+
+## [2.1.5](https://github.com/diegoazh/gmap-vue/compare/gmv3_v2.1.4...gmv3_v2.1.5) (2025-01-03)
+
+
+### Bug Fixes
+
+* upgrade @docusaurus/core from 3.6.2 to 3.6.3 ([#343](https://github.com/diegoazh/gmap-vue/issues/343)) ([d5ca7ea](https://github.com/diegoazh/gmap-vue/commit/d5ca7ea8e72baf933ada171c1c1fef731fcc8429))
+* upgrade @docusaurus/preset-classic from 3.6.2 to 3.6.3 ([#344](https://github.com/diegoazh/gmap-vue/issues/344)) ([10b60e5](https://github.com/diegoazh/gmap-vue/commit/10b60e53ae2c75a2410f3a4107ba5799d8d761af))
+
+## [2.1.4](https://github.com/diegoazh/gmap-vue/compare/gmv3_v2.1.3...gmv3_v2.1.4) (2025-01-03)
+
+
+### Bug Fixes
+
+* **v3:** update 'useTemplateRef' key ([#342](https://github.com/diegoazh/gmap-vue/issues/342)) ([b55f623](https://github.com/diegoazh/gmap-vue/commit/b55f623432650420942f11808959471d9f6481b2))
+
+## [2.1.3](https://github.com/diegoazh/gmap-vue/compare/gmv3_v2.1.2...gmv3_v2.1.3) (2024-11-15)
+
+
+### Bug Fixes
+
+* packages/documentation/package.json to reduce vulnerabilities ([#330](https://github.com/diegoazh/gmap-vue/issues/330)) ([2e2046f](https://github.com/diegoazh/gmap-vue/commit/2e2046fcfc4f7e88e86f39dcd72cc514781175fe))
+* packages/documentation/package.json to reduce vulnerabilities ([#332](https://github.com/diegoazh/gmap-vue/issues/332)) ([4b7b524](https://github.com/diegoazh/gmap-vue/commit/4b7b5244bc208c6495c6b5c4733d7fb84a38c099))
+* upgrade @docusaurus/core from 3.2.0 to 3.2.1 ([#326](https://github.com/diegoazh/gmap-vue/issues/326)) ([955c35b](https://github.com/diegoazh/gmap-vue/commit/955c35bca5913eebb80c3f96c519f582656d6bbb))
+* upgrade @docusaurus/preset-classic from 3.2.0 to 3.2.1 ([#325](https://github.com/diegoazh/gmap-vue/issues/325)) ([dc6ed1b](https://github.com/diegoazh/gmap-vue/commit/dc6ed1bc1f9cb411f955f98f6a6e03498d4e46af))
+
 ## [2.1.2](https://github.com/diegoazh/gmap-vue/compare/gmv3_v2.1.1...gmv3_v2.1.2) (2024-04-24)
 
 

--- a/packages/v2/README.md
+++ b/packages/v2/README.md
@@ -1,111 +1,126 @@
-# GmapVue for Vue v2
+# @gmap-vue/v2
 
-[![Build Status](https://travis-ci.org/diegoazh/gmap-vue.svg?branch=master)](https://travis-ci.org/diegoazh/gmap-vue)
-[![jsdelivr CDN](https://data.jsdelivr.com/v1/package/npm/gmap-vue/badge)](https://www.jsdelivr.com/package/npm/gmap-vue)
+[![CI](https://github.com/diegoazh/gmap-vue/actions/workflows/ci.yml/badge.svg)](https://github.com/diegoazh/gmap-vue/actions/workflows/ci.yml)
+[![Documentation](https://github.com/diegoazh/gmap-vue/actions/workflows/documentation.yml/badge.svg)](https://github.com/diegoazh/gmap-vue/actions/workflows/documentation.yml)
+[![jsDelivr](https://data.jsdelivr.com/v1/package/npm/@gmap-vue/v2/badge)](https://www.jsdelivr.com/package/npm/@gmap-vue/v2)
 
-## Deprecated
+Legacy Vue 2 package for GmapVue.
 
-This plugin for Vue v2 is not longer maintained, please use Vue v3 and use the version of this plugin for it.
+`@gmap-vue/v2` wraps the Google Maps JavaScript API in Vue 2 components. It is maintained for existing Vue 2 applications, while new applications should use [`@gmap-vue/v3`](https://www.npmjs.com/package/@gmap-vue/v3).
+
+## Status
+
+Vue 2 support is legacy maintenance only. Expect compatibility fixes and documentation corrections, not new feature development. If you are starting a new project, use Vue 3 and `@gmap-vue/v3`.
 
 ## Documentation
 
-The new documentation page is ready and it contains all examples for any component in the plugin.
-
-You can use your own gmap key in order to test it in the live example section.
-
-We have planed improve and grow all required documentation about the plugin.
-
-Please follow next link to our [documentation](https://diegoazh.github.io/gmap-vue/).
-
-## Vue-2 port of vue-google-maps
-
-This is a fork of the popular vue2-google-maps. As the author of the library no longer commit to maintain the project, we forked it to develop and maintain the project.
-
-## CONTRIBUTORS NEEDED!
-
-If you have time to contribute to a rather frequently used library, feel free to make a PR!
-For more background, please refer to [this issue](https://github.com/xkjyeah/vue-google-maps/issues/514).
-
-What's urgently needed are:
-
-1. Better automated tests
-2. Better integration tests with the popular frameworks, especially Nuxt and Vue template
-3. ~Better documentation (examples, recommendations)~
-
-The above three will go a long way to keeping the project maintainable and contributable, and will address many of the open issues.
-
-## Breaking changes
-
-### v3.0.0
-
-- `autobindAllEvents` config option was renamed to `autoBindAllEvents`
-- `vueGoogleMapsInit` name was renamed to `GoogleMapsCallback`
-- `gmapApi` function was renamed to `getGoogleMapsAPI`
-- `MapElementMixin` now is exported from `components` object instead of `helpers` object
-- `customCallback` config option was added to reuse existing Google Maps API that already loaded, eg from an HTML file
-
-### v2.0.0
-
-- All components were rewriting in SFC (`.vue`)
-- `MarkerCluster` was renamed to `Cluster`
-- `@google/markerclustererplus` was replace for `@googlemaps/markerclusterer`
-- The plugin exports two main objects:
-  - `components`: it has all components and mountable mixin)
-  - `helpers`: it has promise lazy factory function, gmapApi function and map element mixin
-- The plugin now exports by default the install function, this means that you can do the following
-- From **v2.0.0** and above, the `autocomplete` component uses the `default` slot instead of the named `input` slot, from v1.5.0 the `input` slot on the autocomplete component still works.
-
-  ```js
-  import GmapVue from 'gmap-vue';
-  ```
-
-  instead of
-
-  ```js
-  import * as GmapVue from 'gmap-vue';
-  ```
+- [Vue 2 legacy documentation](https://diegoazh.github.io/gmap-vue/docs/vue-2-version/)
+- [Vue 3 documentation](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/)
+- [Repository README](https://github.com/diegoazh/gmap-vue#readme)
 
 ## Installation
 
-### npm
-
-```shell
-npm install gmap-vue --save
+```bash
+npm install @gmap-vue/v2
 ```
 
-### yarn
-
-```shell
-yarn add gmap-vue
+```bash
+pnpm add @gmap-vue/v2
 ```
 
-### Manually
+```bash
+yarn add @gmap-vue/v2
+```
 
-Just download `dist/gmap-vue.js` file and include it from your HTML.
+## Quick start
+
+```js
+import Vue from 'vue';
+import GmapVue from '@gmap-vue/v2';
+
+Vue.use(GmapVue, {
+  load: {
+    key: process.env.VUE_APP_GOOGLE_MAPS_API_KEY,
+    libraries: 'places',
+  },
+});
+```
+
+```vue
+<template>
+  <GmapMap
+    :center="{ lat: -34.6037, lng: -58.3816 }"
+    :zoom="12"
+    style="width: 100%; height: 500px"
+  >
+    <GmapMarker :position="{ lat: -34.6037, lng: -58.3816 }" />
+  </GmapMap>
+</template>
+```
+
+## Browser builds
+
+The package publishes UMD/IIFE bundles for legacy browser usage. Prefer npm/pnpm/yarn package installation for application builds.
 
 ```html
-<script src="./gmap-vue.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@gmap-vue/v2@3.5.4/dist/gmap-vue.min.js"></script>
 ```
 
-### jsdelivr
+When using browser builds, use kebab-case component names in in-DOM templates, for example `<gmap-map>` instead of `<GmapMap>`.
 
-You can use a free CDN like [jsdelivr](https://www.jsdelivr.com) to include this plugin in your html file
+## Public components
 
-```html
-<script src="https://cdn.jsdelivr.net/npm/gmap-vue@1.2.2/dist/gmap-vue.min.js"></script>
-```
+When `installComponents` is enabled, the plugin registers:
 
-### unpkg
+- `GmapMap`
+- `GmapMarker`
+- `GmapInfoWindow`
+- `GmapHeatmapLayer`
+- `GmapKmlLayer`
+- `GmapPolyline`
+- `GmapPolygon`
+- `GmapCircle`
+- `GmapRectangle`
+- `GmapDrawingManager`
+- `GmapAutocomplete`
+- `GmapPlaceInput`
+- `GmapStreetViewPanorama`
 
-You can use a free CDN like [unpkg](https://unpkg.com) to include this plugin in your html file
+## Google Maps API key
 
-```html
-<script src="https://unpkg.com/gmap-vue@1.2.2/dist/gmap-vue.js"></script>
-```
+You need a browser API key for the Google Maps JavaScript API. For production applications:
 
-::: warning
-Be aware that if you use this method, you cannot use TitleCase for your components and your attributes.
-That is, instead of writing `<GmapMap>`, you need to write `<gmap-map>`.
-:::
+- restrict the key by HTTP referrer,
+- enable only the APIs and libraries your app uses,
+- monitor billing and quota in Google Cloud Console,
+- avoid calling paid APIs from high-frequency map events.
 
-[Live example](https://diegoazh.github.io/gmap-vue/guide/).
+## Migrating to Vue 3
+
+The Vue 3 package changes the package name, component names, TypeScript support, and instance-access patterns. See the [Vue 3 migration guide](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/#migrating-from-version-for-vue-2) before migrating.
+
+## Breaking changes history
+
+### v3.0.0
+
+- `autobindAllEvents` was renamed to `autoBindAllEvents`.
+- `vueGoogleMapsInit` was renamed to `GoogleMapsCallback`.
+- `gmapApi` was renamed to `getGoogleMapsAPI`.
+- `MapElementMixin` is exported from the `components` object instead of the `helpers` object.
+- `customCallback` was added to reuse a Google Maps API script that is already loaded.
+
+### v2.0.0
+
+- Components were rewritten as Vue single-file components.
+- `MarkerCluster` was renamed to `Cluster`.
+- `@google/markerclustererplus` was replaced with `@googlemaps/markerclusterer`.
+- The plugin exports `components` and `helpers` objects.
+- The default export is the plugin install object, so consumers should use:
+
+  ```js
+  import GmapVue from '@gmap-vue/v2';
+  ```
+
+## Contributing
+
+Contributions are welcome for compatibility fixes, documentation, and validation improvements. Please read the repository-level [`README.md`](https://github.com/diegoazh/gmap-vue#readme), [`AGENTS.md`](https://github.com/diegoazh/gmap-vue/blob/master/AGENTS.md), and [Copilot instructions](https://github.com/diegoazh/gmap-vue/blob/master/.github/copilot-instructions.md) before opening a PR.

--- a/packages/v3/README.md
+++ b/packages/v3/README.md
@@ -1,42 +1,92 @@
-# GmapVue for Vue 3
+# @gmap-vue/v3
 
-[![Publish](https://github.com/diegoazh/gmap-vue/workflows/publish/badge.svg)](https://github.com/diegoazh/gmap-vue/actions?query=workflow%3Apublish)
-[![Documentation](https://github.com/diegoazh/gmap-vue/workflows/documentation/badge.svg)](https://github.com/diegoazh/gmap-vue/actions?query=workflow%3Adocumentation)
-[![](https://data.jsdelivr.com/v1/package/npm/@gmap-vue/v3/badge)](https://www.jsdelivr.com/package/npm/@gmap-vue/v3)
+[![CI](https://github.com/diegoazh/gmap-vue/actions/workflows/ci.yml/badge.svg)](https://github.com/diegoazh/gmap-vue/actions/workflows/ci.yml)
+[![Documentation](https://github.com/diegoazh/gmap-vue/actions/workflows/documentation.yml/badge.svg)](https://github.com/diegoazh/gmap-vue/actions/workflows/documentation.yml)
+[![jsDelivr](https://data.jsdelivr.com/v1/package/npm/@gmap-vue/v3/badge)](https://www.jsdelivr.com/package/npm/@gmap-vue/v3)
+
+Vue 3 components and composables for the Google Maps JavaScript API.
+
+`@gmap-vue/v3` is the actively developed GmapVue package. It provides Vue wrappers for maps, markers, info windows, shapes, clusters, layers, autocomplete, and Street View, plus composables for accessing the underlying Google Maps instances.
+
+## Documentation
+
+- [Vue 3 guide](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/)
+- [Component API reference](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/api/components/)
+- [Composables API](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/api/composables/)
 
 ## Installation
 
-### npm
-
-```shell
+```bash
 npm install @gmap-vue/v3
 ```
 
-### pnpm
-
-```shell
+```bash
 pnpm add @gmap-vue/v3
 ```
 
-### yarn
-
-```shell
+```bash
 yarn add @gmap-vue/v3
 ```
 
-## [Documentation](https://diegoazh.github.io/gmap-vue/)
+## Quick start
 
-You can find the documentation following the [link](https://diegoazh.github.io/gmap-vue/).
+Register the plugin once in your Vue app:
 
-## Migrating from version for Vue 2
+```ts
+import { createApp } from 'vue';
+import { createGmapVuePlugin } from '@gmap-vue/v3';
+import '@gmap-vue/v3/dist/style.css';
+import App from './App.vue';
 
-In the new version of this plugin for Vue v3 we introduce many changes on the structure and also we tried to improve some names to be more intuitive. Please for more detail refer to our [documentation](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/#migrating-from-version-for-vue-2).
+createApp(App)
+  .use(
+    createGmapVuePlugin({
+      load: {
+        key: import.meta.env.VITE_GOOGLE_MAPS_API_KEY,
+      },
+    }),
+  )
+  .mount('#app');
+```
 
-## CONTRIBUTORS ARE WELCOME
+Then use the public components in your templates:
 
-If you have time to contribute to a rather frequently used library, feel free to make a PR!, but first please read our [contributing guide](https://github.com/diegoazh/gmap-vue/blob/master/CONTRIBUTING.md).
+```vue
+<template>
+  <GmvMap
+    :center="{ lat: -34.6037, lng: -58.3816 }"
+    :zoom="12"
+    style="width: 100%; height: 500px"
+  >
+    <GmvMarker :position="{ lat: -34.6037, lng: -58.3816 }" />
+  </GmvMap>
+</template>
+```
 
-What's urgently needed are:
+## Google Maps API key
 
-1. Better unit tests (we use Vitest).
-2. Better integration tests (we use Cypress)
+You need a browser API key for the Google Maps JavaScript API. For production applications:
+
+- restrict the key by HTTP referrer,
+- enable only the APIs and libraries your app uses,
+- monitor billing and quota in Google Cloud Console,
+- avoid calling paid APIs from high-frequency map events.
+
+## Public entrypoints
+
+Use the package entrypoints instead of deep imports:
+
+```ts
+import { createGmapVuePlugin, GmvMap } from '@gmap-vue/v3';
+import { useMapPromise } from '@gmap-vue/v3/composables';
+import { mapPromiseKey } from '@gmap-vue/v3/keys';
+import type { IMapLayerVueComponentExpose } from '@gmap-vue/v3/interfaces';
+```
+
+## Migrating from Vue 2
+
+The Vue 3 package changes the plugin structure, component names, and instance-access patterns. See the [Vue 3 migration guide](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/#migrating-from-version-for-vue-2) before migrating from `@gmap-vue/v2`.
+
+## Contributing
+
+Contributions are welcome. Please read the repository-level [`README.md`](https://github.com/diegoazh/gmap-vue#readme), [`AGENTS.md`](https://github.com/diegoazh/gmap-vue/blob/master/AGENTS.md), and [Copilot instructions](https://github.com/diegoazh/gmap-vue/blob/master/.github/copilot-instructions.md) before opening a PR.


### PR DESCRIPTION
## Summary

- Refresh the root README, both package READMEs, and the documentation package README with clearer project/package overviews, quickstarts, validation commands, badges, and contribution guidance.
- Replace AGENTS.md with a Prowler-style repository guide covering skills, auto-invoke routing, package-specific guidance, validation policy, and OpenSpec/Gentle AI artifacts.
- Add the missing OpenSpec base config, sync Copilot/skill-registry guidance with current workflows/tooling, ignore local agent runtime folders, and update docs changelogs with missing Vue 2/Vue 3 releases.

## Changes

| File | Change |
| --- | --- |
| `README.md` | Reworked root README for users and contributors. |
| `packages/v3/README.md` | Reworked npm-facing package README with current badges, docs links, quickstart, API-key notes, and public entrypoints. |
| `packages/v2/README.md` | Reworked legacy package README with current package name, legacy status, quickstart, browser-build guidance, API-key notes, and migration guidance. |
| `packages/documentation/README.md` | Expanded docs-package README with structure, local development, validation, content direction, navigation, and deployment notes. |
| `AGENTS.md` | Replaced the long agent inventory with concise repository guidelines and package policies. |
| `.github/copilot-instructions.md` | Updated stale pnpm, Docusaurus, CI, docs workflow, and release facts. |
| `.atl/skill-registry.md` | Synchronized current docs/tooling/release guidance. |
| `openspec/config.yaml` | Added base OpenSpec/Gentle AI project config. |
| `.gitignore` | Ignored `.claude/`, `.codex/`, and `.pi/` local runtime folders. |
| `packages/documentation/docs/vue-2-version/changelog/changelog.md` | Added missing v2 release entries. |
| `packages/documentation/docs/vue-3-version/changelog/changelog.md` | Added missing v3 release entries through 2.2.1. |

## Validation

- [x] `git diff --check`
- [x] `python3 - <<'PY' ... yaml.safe_load('openspec/config.yaml') ... PY`
- [x] `pnpm run lint`
- [x] `pnpm run --filter docs typecheck`
- [x] `pnpm run --filter docs build`
- [x] `pnpm run test`
- [ ] `pnpm run test:e2e`, currently blocked by the known external Google Maps billing configuration issue. The run reached Cypress, 10 of 11 specs passed, and only `autocomplete-input.cy.ts` failed with: `Google Maps billing is not enabled for VITE_GOOGLE_API_KEY`.

## Notes

- `research.md` remains untracked and was not included in this PR.
- Fresh review subagents returned GO for the repository-guidance changes and for the changelog additions.
