### PR TITLE
docs(root): clarify vue 2 frozen status

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  Google Maps components and composables for Vue 3, with legacy Vue 2 support.
+  Google Maps components and composables for Vue 3. The Vue 2 package is frozen and kept only for existing applications.
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 GmapVue is a pnpm monorepo that provides Vue wrappers for the Google Maps JavaScript API.
 
 - **Vue 3 package:** `@gmap-vue/v3`, the actively developed package.
-- **Vue 2 package:** `@gmap-vue/v2`, maintained for legacy applications.
+- **Vue 2 package:** `@gmap-vue/v2`, frozen and no longer actively maintained. Existing Vue 2 apps can keep using it, but migration to Vue 3 is recommended.
 - **Documentation:** Docusaurus site published at <https://diegoazh.github.io/gmap-vue/>.
 
 The project is a maintained fork of `vue2-google-maps`, updated to support modern Vue, typed package entrypoints, and component-level access to Google Maps instances.
@@ -36,7 +36,7 @@ Start with the published docs:
 | Package | Location | Status | Purpose |
 | --- | --- | --- | --- |
 | `@gmap-vue/v3` | `packages/v3` | Active | Vue 3 plugin, components, composables, keys, interfaces, and types. |
-| `@gmap-vue/v2` | `packages/v2` | Legacy | Vue 2 plugin maintained for existing applications. |
+| `@gmap-vue/v2` | `packages/v2` | Frozen legacy | Vue 2 plugin kept for existing applications. No active maintenance; migrate to `@gmap-vue/v3` when possible. |
 | `docs` | `packages/documentation` | Active | Docusaurus documentation site. |
 
 ## Install

--- a/packages/documentation/docs/vue-2-version/code/README.md
+++ b/packages/documentation/docs/vue-2-version/code/README.md
@@ -4,36 +4,19 @@ id: introduction
 sidebar_position: 1
 sidebar_label: Introduction
 ---
-# GmapVue
+# GmapVue Vue 2 API notes
 
-[![](https://data.jsdelivr.com/v1/package/npm/gmap-vue/badge)](https://www.jsdelivr.com/package/npm/gmap-vue)
+[![jsDelivr](https://data.jsdelivr.com/v1/package/npm/@gmap-vue/v2/badge)](https://www.jsdelivr.com/package/npm/@gmap-vue/v2)
 
-## Documentation
+:::danger
+The Vue 2 package is frozen and no longer actively maintained because Vue 2 reached EOL.
+:::
 
-The new documentation page is ready and it contains all examples for any component in the plugin.
+Use this API documentation only for existing Vue 2 applications that cannot migrate yet. New applications should use [`@gmap-vue/v3`](/docs/vue-3-version/).
 
-You can use your own gmap key in order to test it in the live example section.
+## Vue 2 port history
 
-We have planed improve and grow all required documentation about the plugin.
-
-Please follow next link to our [documentation](https://diegoazh.github.io/gmap-vue/).
-
-## Vue-2 port of vue-google-maps
-
-This is a fork of the popular vue2-google-maps. As the author of the library no longer commit to maintain the project, we forked it to develop and maintain the project.
-
-## CONTRIBUTORS NEEDED!
-
-If you have time to contribute to a rather frequently used library, feel free to make a PR!
-For more background, please refer to [this issue](https://github.com/xkjyeah/vue-google-maps/issues/514).
-
-What's urgently needed are:
-
-1. Better automated tests
-2. Better integration tests with the popular frameworks, especially Nuxt and Vue template
-3. ~Better documentation (examples, recommendations)~
-
-The above three will go a long way to keeping the project maintainable and contributable, and will address many of the open issues.
+GmapVue started as a fork of the popular `vue2-google-maps` project so community fixes could continue after the original project slowed down. That history is preserved here for existing Vue 2 users, but new feature development now belongs in the Vue 3 package.
 
 ## Breaking changes
 

--- a/packages/documentation/docs/vue-2-version/index.md
+++ b/packages/documentation/docs/vue-2-version/index.md
@@ -28,14 +28,13 @@ to [v0.10.8](https://github.com/xkjyeah/vue-google-maps/releases/tag/v0.10.8), b
 the last features** added to `vue2-google-maps` repository by the community developers in many PRs, that they can't
 landed in a new version of that project, for different reasons.
 
-Because of that we fork the project and plain to continue working and adding new features to this great plugin.
+That history explains why this package exists, but the Vue 2 package is now frozen. Use this documentation only for existing Vue 2 applications that cannot migrate yet.
 
 ## Breaking changes
 
 :::warning
 
-We have planned to change all components names and file names to the same way that they are registered for the next
-major release (v4.0.0).
+This legacy Vue 2 package is frozen and no v4 line is planned here. Use the Vue 3 package for current component names and new work.
 
 :::
 

--- a/packages/v2/README.md
+++ b/packages/v2/README.md
@@ -6,11 +6,11 @@
 
 Legacy Vue 2 package for GmapVue.
 
-`@gmap-vue/v2` wraps the Google Maps JavaScript API in Vue 2 components. It is maintained for existing Vue 2 applications, while new applications should use [`@gmap-vue/v3`](https://www.npmjs.com/package/@gmap-vue/v3).
+`@gmap-vue/v2` wraps the Google Maps JavaScript API in Vue 2 components. This package is frozen and kept only for existing Vue 2 applications; new applications should use [`@gmap-vue/v3`](https://www.npmjs.com/package/@gmap-vue/v3).
 
 ## Status
 
-Vue 2 support is legacy maintenance only. Expect compatibility fixes and documentation corrections, not new feature development. If you are starting a new project, use Vue 3 and `@gmap-vue/v3`.
+Vue 2 support is frozen because Vue 2 reached EOL. There is no active maintenance for this package. If you are starting a new project, use Vue 3 and `@gmap-vue/v3`; if you already depend on Vue 2, plan a migration when possible.
 
 ## Documentation
 
@@ -123,4 +123,4 @@ The Vue 3 package changes the package name, component names, TypeScript support,
 
 ## Contributing
 
-Contributions are welcome for compatibility fixes, documentation, and validation improvements. Please read the repository-level [`README.md`](https://github.com/diegoazh/gmap-vue#readme), [`AGENTS.md`](https://github.com/diegoazh/gmap-vue/blob/master/AGENTS.md), and [Copilot instructions](https://github.com/diegoazh/gmap-vue/blob/master/.github/copilot-instructions.md) before opening a PR.
+This package is not actively maintained. If you need new work, target `@gmap-vue/v3` instead. For repository contributions, read the repository-level [`README.md`](https://github.com/diegoazh/gmap-vue#readme), [`AGENTS.md`](https://github.com/diegoazh/gmap-vue/blob/master/AGENTS.md), and [Copilot instructions](https://github.com/diegoazh/gmap-vue/blob/master/.github/copilot-instructions.md) before opening a PR.


### PR DESCRIPTION
## Summary

- Clarify in the root README that `@gmap-vue/v2` is frozen, no longer actively maintained, and kept only for existing Vue 2 applications.
- Align the v2 package README with the same frozen/no-active-maintenance messaging.
- Remove stale Vue 2 docs text that implied future v2 feature work or a planned v4 line.

## Validation

- [x] `git diff --check`
- [x] `pnpm run --filter docs typecheck`
- [x] `pnpm run --filter docs build`
- [x] `pnpm run lint`

## Notes

`research.md` remains untracked and was not included.
