### PR TITLE
docs(root): add context7 configuration

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "GmapVue",
+  "description": "Vue 3 components and composables for the Google Maps JavaScript API, with a frozen legacy Vue 2 package.",
+  "branch": "master",
+  "folders": [
+    "packages/v3",
+    "packages/v2",
+    "packages/documentation",
+    "packages/documentation/docs/vue-3-version",
+    "packages/documentation/docs/vue-2-version"
+  ],
+  "excludeFolders": [
+    "node_modules",
+    "**/node_modules",
+    "packages/**/dist",
+    "packages/**/.pack",
+    "packages/documentation/build",
+    "packages/documentation/.docusaurus",
+    "packages/old-documentation",
+    "packages/v3/src",
+    "packages/v3/tests",
+    "packages/v3/cypress",
+    "packages/v2/src"
+  ],
+  "excludeFiles": [
+    "CHANGELOG.md",
+    "changelog.md"
+  ],
+  "rules": [
+    "Use @gmap-vue/v3 for new Vue applications.",
+    "Treat @gmap-vue/v2 as frozen legacy documentation only. Do not recommend it for new projects.",
+    "Use documented package entrypoints instead of deep imports.",
+    "When showing Google Maps examples, mention API key restrictions, enabled APIs, billing, and optional library loading.",
+    "Avoid examples that call paid Google Maps or Places APIs from high-frequency events."
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `context7.json` so Context7 can index the right GmapVue documentation sources.
- Prioritize Vue 3 docs and package README content while keeping Vue 2 available as frozen legacy documentation.
- Exclude generated output, local package builds, tests, source folders, and old documentation from Context7 parsing.

## Validation

- [x] `python3 -m json.tool context7.json`
- [x] `git diff --check`
- [x] `pnpm run lint`

## Follow-up after merge

Submit the repository to Context7:

https://context7.com/add-library?tab=github

Repository URL:

```text
https://github.com/diegoazh/gmap-vue
```

## Notes

`research.md` remains untracked and was not included.
