### PR TITLE
docs(v2): use published legacy package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 GmapVue is a pnpm monorepo that provides Vue wrappers for the Google Maps JavaScript API.
 
 - **Vue 3 package:** `@gmap-vue/v3`, the actively developed package.
-- **Vue 2 package:** `@gmap-vue/v2`, frozen and no longer actively maintained. Existing Vue 2 apps can keep using it, but migration to Vue 3 is recommended.
+- **Vue 2 package:** `gmap-vue`, frozen and no longer actively maintained. Existing Vue 2 apps can keep using it, but migration to Vue 3 is recommended.
 - **Documentation:** Docusaurus site published at <https://diegoazh.github.io/gmap-vue/>.
 
 The project is a maintained fork of `vue2-google-maps`, updated to support modern Vue, typed package entrypoints, and component-level access to Google Maps instances.
@@ -36,7 +36,7 @@ Start with the published docs:
 | Package | Location | Status | Purpose |
 | --- | --- | --- | --- |
 | `@gmap-vue/v3` | `packages/v3` | Active | Vue 3 plugin, components, composables, keys, interfaces, and types. |
-| `@gmap-vue/v2` | `packages/v2` | Frozen legacy | Vue 2 plugin kept for existing applications. No active maintenance; migrate to `@gmap-vue/v3` when possible. |
+| `gmap-vue` | `packages/v2` | Frozen legacy | Vue 2 plugin kept for existing applications. No active maintenance; migrate to `@gmap-vue/v3` when possible. |
 | `docs` | `packages/documentation` | Active | Docusaurus documentation site. |
 
 ## Install

--- a/context7.json
+++ b/context7.json
@@ -29,7 +29,7 @@
   ],
   "rules": [
     "Use @gmap-vue/v3 for new Vue applications.",
-    "Treat @gmap-vue/v2 as frozen legacy documentation only. Do not recommend it for new projects.",
+    "Treat the legacy gmap-vue Vue 2 package as frozen documentation only. Do not recommend it for new projects.",
     "Use documented package entrypoints instead of deep imports.",
     "When showing Google Maps examples, mention API key restrictions, enabled APIs, billing, and optional library loading.",
     "Avoid examples that call paid Google Maps or Places APIs from high-frequency events."

--- a/packages/documentation/docs/vue-2-version/code/README.md
+++ b/packages/documentation/docs/vue-2-version/code/README.md
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 ---
 # GmapVue Vue 2 API notes
 
-[![jsDelivr](https://data.jsdelivr.com/v1/package/npm/@gmap-vue/v2/badge)](https://www.jsdelivr.com/package/npm/@gmap-vue/v2)
+[![jsDelivr](https://data.jsdelivr.com/v1/package/npm/gmap-vue/badge)](https://www.jsdelivr.com/package/npm/gmap-vue)
 
 :::danger
 The Vue 2 package is frozen and no longer actively maintained because Vue 2 reached EOL.

--- a/packages/v2/README.md
+++ b/packages/v2/README.md
@@ -1,12 +1,12 @@
-# @gmap-vue/v2
+# gmap-vue
 
 [![CI](https://github.com/diegoazh/gmap-vue/actions/workflows/ci.yml/badge.svg)](https://github.com/diegoazh/gmap-vue/actions/workflows/ci.yml)
 [![Documentation](https://github.com/diegoazh/gmap-vue/actions/workflows/documentation.yml/badge.svg)](https://github.com/diegoazh/gmap-vue/actions/workflows/documentation.yml)
-[![jsDelivr](https://data.jsdelivr.com/v1/package/npm/@gmap-vue/v2/badge)](https://www.jsdelivr.com/package/npm/@gmap-vue/v2)
+[![jsDelivr](https://data.jsdelivr.com/v1/package/npm/gmap-vue/badge)](https://www.jsdelivr.com/package/npm/gmap-vue)
 
 Legacy Vue 2 package for GmapVue.
 
-`@gmap-vue/v2` wraps the Google Maps JavaScript API in Vue 2 components. This package is frozen and kept only for existing Vue 2 applications; new applications should use [`@gmap-vue/v3`](https://www.npmjs.com/package/@gmap-vue/v3).
+`gmap-vue` wraps the Google Maps JavaScript API in Vue 2 components. This package is frozen and kept only for existing Vue 2 applications; new applications should use [`@gmap-vue/v3`](https://www.npmjs.com/package/@gmap-vue/v3).
 
 ## Status
 
@@ -21,22 +21,22 @@ Vue 2 support is frozen because Vue 2 reached EOL. There is no active maintenanc
 ## Installation
 
 ```bash
-npm install @gmap-vue/v2
+npm install gmap-vue
 ```
 
 ```bash
-pnpm add @gmap-vue/v2
+pnpm add gmap-vue
 ```
 
 ```bash
-yarn add @gmap-vue/v2
+yarn add gmap-vue
 ```
 
 ## Quick start
 
 ```js
 import Vue from 'vue';
-import GmapVue from '@gmap-vue/v2';
+import GmapVue from 'gmap-vue';
 
 Vue.use(GmapVue, {
   load: {
@@ -63,7 +63,7 @@ Vue.use(GmapVue, {
 The package publishes UMD/IIFE bundles for legacy browser usage. Prefer npm/pnpm/yarn package installation for application builds.
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@gmap-vue/v2@3.5.4/dist/gmap-vue.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gmap-vue@3.5.4/dist/gmap-vue.min.js"></script>
 ```
 
 When using browser builds, use kebab-case component names in in-DOM templates, for example `<gmap-map>` instead of `<GmapMap>`.
@@ -118,7 +118,7 @@ The Vue 3 package changes the package name, component names, TypeScript support,
 - The default export is the plugin install object, so consumers should use:
 
   ```js
-  import GmapVue from '@gmap-vue/v2';
+  import GmapVue from 'gmap-vue';
   ```
 
 ## Contributing

--- a/packages/v3/README.md
+++ b/packages/v3/README.md
@@ -85,7 +85,7 @@ import type { IMapLayerVueComponentExpose } from '@gmap-vue/v3/interfaces';
 
 ## Migrating from Vue 2
 
-The Vue 3 package changes the plugin structure, component names, and instance-access patterns. See the [Vue 3 migration guide](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/#migrating-from-version-for-vue-2) before migrating from `@gmap-vue/v2`.
+The Vue 3 package changes the plugin structure, component names, and instance-access patterns. See the [Vue 3 migration guide](https://diegoazh.github.io/gmap-vue/docs/vue-3-version/#migrating-from-version-for-vue-2) before migrating from the legacy `gmap-vue` package.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Correct public Vue 2 legacy package references from `@gmap-vue/v2` to the published npm package `gmap-vue`.
- Update root README, v2/v3 package READMEs, Vue 2 docs API notes, and Context7 guidance.
- Keep Vue 2 messaging frozen/no-active-maintenance with migration to `@gmap-vue/v3` recommended.

## Validation

- [x] `npm view gmap-vue version dist-tags --json`
- [x] `npm view @gmap-vue/v3 version dist-tags --json`
- [x] `npm view @gmap-vue/v2 versions --json` returns 404, confirming it is not published
- [x] `git diff --check`
- [x] `python3 -m json.tool context7.json`
- [x] `pnpm run --filter docs typecheck`
- [x] `pnpm run --filter docs build`
- [x] `pnpm run lint`

## Notes

Internal workspace commands may still use `--filter @gmap-vue/v2` because that is the local workspace package name in `packages/v2/package.json`. This PR only fixes public npm/docs references.

`research.md` remains untracked and was not included.
